### PR TITLE
Google Analiticsの導入・半径1.5km以内に修正・独自ドメインの設定

### DIFF
--- a/app/controllers/greenteas_controller.rb
+++ b/app/controllers/greenteas_controller.rb
@@ -10,7 +10,7 @@ class GreenteasController < ApplicationController
     @greentea = Greentea.find(params[:id])
     @longitude = @greentea.longitude
     @latitude = @greentea.latitude
-    @temples = Temple.all.within(2.0, origin: [@latitude, @longitude]).by_distance(origin: [@latitude, @longitude])
+    @temples = Temple.all.within(1.5, origin: [@latitude, @longitude]).by_distance(origin: [@latitude, @longitude])
   end
 
   def greentea_likes

--- a/app/controllers/temples_controller.rb
+++ b/app/controllers/temples_controller.rb
@@ -10,7 +10,7 @@ class TemplesController < ApplicationController
     @temple = Temple.find(params[:id])
     @longitude = @temple.longitude
     @latitude = @temple.latitude
-    @greenteas = Greentea.all.within(2.0, origin: [@latitude, @longitude]).by_distance(origin: [@latitude, @longitude])
+    @greenteas = Greentea.all.within(1.5, origin: [@latitude, @longitude]).by_distance(origin: [@latitude, @longitude])
   end
 
   def temple_likes

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
+
       gtag('config', 'G-T9K0D5NVDL');
     </script>
   </head>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,15 +11,14 @@
     <%= javascript_include_tag 'application', "data-turbo-track": 'reload', defer: true %>
     <%= favicon_link_tag('logo2.png') %>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6L4KZPC2EP"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-T9K0D5NVDL"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-6L4KZPC2EP');
+      gtag('config', 'G-T9K0D5NVDL');
     </script>
   </head>
-
   <body>
     <% if logged_in? %>
       <%= render 'shared/header' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,14 @@
     <%= stylesheet_link_tag 'application', "data-turbo-track": 'reload' %>
     <%= javascript_include_tag 'application', "data-turbo-track": 'reload', defer: true %>
     <%= favicon_link_tag('logo2.png') %>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6L4KZPC2EP"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-6L4KZPC2EP');
+    </script>
   </head>
 
   <body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,12 +11,12 @@
     <%= javascript_include_tag 'application', "data-turbo-track": 'reload', defer: true %>
     <%= favicon_link_tag('logo2.png') %>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-T9K0D5NVDL"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6HMH99N56L"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-T9K0D5NVDL');
+      gtag('config', 'G-6HMH99N56L');
     </script>
   </head>
   <body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,12 +11,12 @@
     <%= javascript_include_tag 'application', "data-turbo-track": 'reload', defer: true %>
     <%= favicon_link_tag('logo2.png') %>
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6HMH99N56L"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-T9K0D5NVDL"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-6HMH99N56L');
+      gtag('config', 'G-T9K0D5NVDL');
     </script>
   </head>
   <body>


### PR DESCRIPTION
## 概要

- Google Analiticsの導入
- 詳細ページで近いお店・神社の半径を1.5km以内に修正
- 独自ドメインの設定

Google Analiticsを導入した後、
設定が反映されていることを確認。
確認後自分のIPアドレスは除外した。
トラッキングコードの貼りつけ方は下記のサイトを参考にした。
https://www.seohacks.net/blog/10545/

## 影響範囲

- app/controllers/greenteas_controller.rb
- app/controllers/temples_controller.rb
- app/views/layouts/application.html.erb

## チェックリスト

プロジェクトごとにパスしなければならないルールを定義しておきましょう。例えば以下のように。

- [ ] Lint のチェックをパスした

## コメント

独自ドメインは11/14に設定。反映待ち。
Closes #68 
Closes #69