### PR TITLE
管理画面の再作成、独自ドメイン取得によるコールバックURL修正、プロフィールページの修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,7 @@ gem 'open_uri_redirections'
 gem 'dotenv-rails'
 
 # 管理画面
+gem "administrate"
 
 # Use Sass to process CSS
 gem "sassc-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,14 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
+    administrate (0.18.0)
+      actionpack (>= 5.0)
+      actionview (>= 5.0)
+      activerecord (>= 5.0)
+      jquery-rails (>= 4.0)
+      kaminari (>= 1.0)
+      sassc-rails (~> 2.1)
+      selectize-rails (~> 0.6)
     ast (2.4.2)
     bcrypt (3.1.18)
     better_html (2.0.1)
@@ -209,6 +217,10 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jquery-rails (4.5.1)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     jsbundling-rails (1.0.3)
       railties (>= 6.0.0)
     json (2.6.2)
@@ -376,6 +388,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    selectize-rails (0.12.6)
     selenium-webdriver (4.5.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -436,6 +449,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-import
+  administrate
   bootsnap
   capybara
   carrierwave (~> 2.0)

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,0 +1,21 @@
+# All Administrate controllers inherit from this
+# `Administrate::ApplicationController`, making it the ideal place to put
+# authentication logic or other before_actions.
+#
+# If you want to add pagination or other controller-level concerns,
+# you're free to overwrite the RESTful controller actions.
+module Admin
+  class ApplicationController < Administrate::ApplicationController
+    before_action :authenticate_admin
+
+    def authenticate_admin
+      # TODO Add authentication logic here.
+    end
+
+    # Override this value to specify the number of elements to display at a time
+    # on index pages. Defaults to 20.
+    # def records_per_page
+    #   params[:per_page] || 20
+    # end
+  end
+end

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -6,8 +6,8 @@
 # you're free to overwrite the RESTful controller actions.
 module Admin
   class ApplicationController < Administrate::ApplicationController
-  before_action :require_login
-  before_action :check_admin 
+    before_action :require_login
+    before_action :check_admin
 
     def authenticate_admin
       not_authenticated

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -6,12 +6,16 @@
 # you're free to overwrite the RESTful controller actions.
 module Admin
   class ApplicationController < Administrate::ApplicationController
-    before_action :authenticate_admin
+  before_action :require_login
+  before_action :check_admin 
 
     def authenticate_admin
-      # TODO Add authentication logic here.
+      not_authenticated
     end
 
+    def check_admin
+      redirect_to root_path, warning: '権限がありません' unless current_user.admin?
+    end
     # Override this value to specify the number of elements to display at a time
     # on index pages. Defaults to 20.
     # def records_per_page

--- a/app/controllers/admin/areas_controller.rb
+++ b/app/controllers/admin/areas_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class AreasController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/admin/authentications_controller.rb
+++ b/app/controllers/admin/authentications_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class AuthenticationsController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/admin/genres_controller.rb
+++ b/app/controllers/admin/genres_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class GenresController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/admin/greentea_genres_controller.rb
+++ b/app/controllers/admin/greentea_genres_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class GreenteaGenresController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/admin/greentea_likes_controller.rb
+++ b/app/controllers/admin/greentea_likes_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class GreenteaLikesController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/admin/greenteas_controller.rb
+++ b/app/controllers/admin/greenteas_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class GreenteasController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/admin/temple_areas_controller.rb
+++ b/app/controllers/admin/temple_areas_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class TempleAreasController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/admin/temple_likes_controller.rb
+++ b/app/controllers/admin/temple_likes_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class TempleLikesController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/admin/temples_controller.rb
+++ b/app/controllers/admin/temples_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class TemplesController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class UsersController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,9 +3,9 @@ class ApplicationController < ActionController::Base
 
   add_flash_types :success, :error, :info
 
-  # private
+  private
 
-  # def not_authenticated
-  #   redirect_to main_app.login_path, info: t('defaults.message.require_login')  # main_appのプレフィックスをつける
-  # end
+  def not_authenticated
+    redirect_to root_path 
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,6 @@ class ApplicationController < ActionController::Base
   private
 
   def not_authenticated
-    redirect_to root_path 
+    redirect_to root_path
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,15 +8,11 @@ class UsersController < ApplicationController
 
   def edit; end
 
-  def show; end
-
-  def create
-    @user = User.new(user_params)
-    if @user.save
-      redirect_to login_path, success: t('.success')
+  def show 
+    if @user == current_user
+      render 'show'
     else
-      flash.now[:error] = t('.fail')
-      render :new
+      redirect_to root_path
     end
   end
 

--- a/app/dashboards/area_dashboard.rb
+++ b/app/dashboards/area_dashboard.rb
@@ -1,0 +1,69 @@
+require "administrate/base_dashboard"
+
+class AreaDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    name: Field::String,
+    temple_areas: Field::HasMany,
+    temples: Field::HasMany,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    name
+    temple_areas
+    temples
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    name
+    temple_areas
+    temples
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    name
+    temple_areas
+    temples
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how areas are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(area)
+  #   "Area ##{area.id}"
+  # end
+end

--- a/app/dashboards/area_dashboard.rb
+++ b/app/dashboards/area_dashboard.rb
@@ -1,4 +1,4 @@
-require "administrate/base_dashboard"
+require 'administrate/base_dashboard'
 
 class AreaDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
@@ -13,7 +13,7 @@ class AreaDashboard < Administrate::BaseDashboard
     temple_areas: Field::HasMany,
     temples: Field::HasMany,
     created_at: Field::DateTime,
-    updated_at: Field::DateTime,
+    updated_at: Field::DateTime
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/dashboards/authentication_dashboard.rb
+++ b/app/dashboards/authentication_dashboard.rb
@@ -1,0 +1,69 @@
+require "administrate/base_dashboard"
+
+class AuthenticationDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    provider: Field::String,
+    uid: Field::String,
+    user: Field::BelongsTo,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    provider
+    uid
+    user
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    provider
+    uid
+    user
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    provider
+    uid
+    user
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how authentications are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(authentication)
+  #   "Authentication ##{authentication.id}"
+  # end
+end

--- a/app/dashboards/authentication_dashboard.rb
+++ b/app/dashboards/authentication_dashboard.rb
@@ -1,4 +1,4 @@
-require "administrate/base_dashboard"
+require 'administrate/base_dashboard'
 
 class AuthenticationDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
@@ -13,7 +13,7 @@ class AuthenticationDashboard < Administrate::BaseDashboard
     uid: Field::String,
     user: Field::BelongsTo,
     created_at: Field::DateTime,
-    updated_at: Field::DateTime,
+    updated_at: Field::DateTime
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/dashboards/genre_dashboard.rb
+++ b/app/dashboards/genre_dashboard.rb
@@ -1,0 +1,69 @@
+require "administrate/base_dashboard"
+
+class GenreDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    greentea_genres: Field::HasMany,
+    greenteas: Field::HasMany,
+    name: Field::String,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    greentea_genres
+    greenteas
+    name
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    greentea_genres
+    greenteas
+    name
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    greentea_genres
+    greenteas
+    name
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how genres are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(genre)
+  #   "Genre ##{genre.id}"
+  # end
+end

--- a/app/dashboards/genre_dashboard.rb
+++ b/app/dashboards/genre_dashboard.rb
@@ -1,4 +1,4 @@
-require "administrate/base_dashboard"
+require 'administrate/base_dashboard'
 
 class GenreDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
@@ -13,7 +13,7 @@ class GenreDashboard < Administrate::BaseDashboard
     greenteas: Field::HasMany,
     name: Field::String,
     created_at: Field::DateTime,
-    updated_at: Field::DateTime,
+    updated_at: Field::DateTime
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/dashboards/greentea_dashboard.rb
+++ b/app/dashboards/greentea_dashboard.rb
@@ -1,0 +1,108 @@
+require "administrate/base_dashboard"
+
+class GreenteaDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    access: Field::String,
+    address: Field::String,
+    business_hours: Field::String,
+    closed: Field::Number,
+    description: Field::Text,
+    genres: Field::HasMany,
+    greentea_genres: Field::HasMany,
+    greentea_likes: Field::HasMany,
+    holiday: Field::String,
+    homepage: Field::String,
+    img: Field::String,
+    latitude: Field::Number.with_options(decimals: 2),
+    longitude: Field::Number.with_options(decimals: 2),
+    name: Field::String,
+    phone_number: Field::String,
+    users: Field::HasMany,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    access
+    address
+    business_hours
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    access
+    address
+    business_hours
+    closed
+    description
+    genres
+    greentea_genres
+    greentea_likes
+    holiday
+    homepage
+    img
+    latitude
+    longitude
+    name
+    phone_number
+    users
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    access
+    address
+    business_hours
+    closed
+    description
+    genres
+    greentea_genres
+    greentea_likes
+    holiday
+    homepage
+    img
+    latitude
+    longitude
+    name
+    phone_number
+    users
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how greenteas are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(greentea)
+  #   "Greentea ##{greentea.id}"
+  # end
+end

--- a/app/dashboards/greentea_dashboard.rb
+++ b/app/dashboards/greentea_dashboard.rb
@@ -1,4 +1,4 @@
-require "administrate/base_dashboard"
+require 'administrate/base_dashboard'
 
 class GreenteaDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
@@ -26,7 +26,7 @@ class GreenteaDashboard < Administrate::BaseDashboard
     phone_number: Field::String,
     users: Field::HasMany,
     created_at: Field::DateTime,
-    updated_at: Field::DateTime,
+    updated_at: Field::DateTime
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/dashboards/greentea_genre_dashboard.rb
+++ b/app/dashboards/greentea_genre_dashboard.rb
@@ -1,4 +1,4 @@
-require "administrate/base_dashboard"
+require 'administrate/base_dashboard'
 
 class GreenteaGenreDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
@@ -12,7 +12,7 @@ class GreenteaGenreDashboard < Administrate::BaseDashboard
     genre: Field::BelongsTo,
     greentea: Field::BelongsTo,
     created_at: Field::DateTime,
-    updated_at: Field::DateTime,
+    updated_at: Field::DateTime
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/dashboards/greentea_genre_dashboard.rb
+++ b/app/dashboards/greentea_genre_dashboard.rb
@@ -1,0 +1,66 @@
+require "administrate/base_dashboard"
+
+class GreenteaGenreDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    genre: Field::BelongsTo,
+    greentea: Field::BelongsTo,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    genre
+    greentea
+    created_at
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    genre
+    greentea
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    genre
+    greentea
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how greentea genres are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(greentea_genre)
+  #   "GreenteaGenre ##{greentea_genre.id}"
+  # end
+end

--- a/app/dashboards/greentea_like_dashboard.rb
+++ b/app/dashboards/greentea_like_dashboard.rb
@@ -1,0 +1,66 @@
+require "administrate/base_dashboard"
+
+class GreenteaLikeDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    greentea: Field::BelongsTo,
+    user: Field::BelongsTo,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    greentea
+    user
+    created_at
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    greentea
+    user
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    greentea
+    user
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how greentea likes are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(greentea_like)
+  #   "GreenteaLike ##{greentea_like.id}"
+  # end
+end

--- a/app/dashboards/greentea_like_dashboard.rb
+++ b/app/dashboards/greentea_like_dashboard.rb
@@ -1,4 +1,4 @@
-require "administrate/base_dashboard"
+require 'administrate/base_dashboard'
 
 class GreenteaLikeDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
@@ -12,7 +12,7 @@ class GreenteaLikeDashboard < Administrate::BaseDashboard
     greentea: Field::BelongsTo,
     user: Field::BelongsTo,
     created_at: Field::DateTime,
-    updated_at: Field::DateTime,
+    updated_at: Field::DateTime
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/dashboards/temple_area_dashboard.rb
+++ b/app/dashboards/temple_area_dashboard.rb
@@ -1,0 +1,66 @@
+require "administrate/base_dashboard"
+
+class TempleAreaDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    area: Field::BelongsTo,
+    temple: Field::BelongsTo,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    area
+    temple
+    created_at
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    area
+    temple
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    area
+    temple
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how temple areas are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(temple_area)
+  #   "TempleArea ##{temple_area.id}"
+  # end
+end

--- a/app/dashboards/temple_area_dashboard.rb
+++ b/app/dashboards/temple_area_dashboard.rb
@@ -1,4 +1,4 @@
-require "administrate/base_dashboard"
+require 'administrate/base_dashboard'
 
 class TempleAreaDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
@@ -12,7 +12,7 @@ class TempleAreaDashboard < Administrate::BaseDashboard
     area: Field::BelongsTo,
     temple: Field::BelongsTo,
     created_at: Field::DateTime,
-    updated_at: Field::DateTime,
+    updated_at: Field::DateTime
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/dashboards/temple_dashboard.rb
+++ b/app/dashboards/temple_dashboard.rb
@@ -1,4 +1,4 @@
-require "administrate/base_dashboard"
+require 'administrate/base_dashboard'
 
 class TempleDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
@@ -25,7 +25,7 @@ class TempleDashboard < Administrate::BaseDashboard
     temple_likes: Field::HasMany,
     users: Field::HasMany,
     created_at: Field::DateTime,
-    updated_at: Field::DateTime,
+    updated_at: Field::DateTime
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/dashboards/temple_dashboard.rb
+++ b/app/dashboards/temple_dashboard.rb
@@ -1,0 +1,105 @@
+require "administrate/base_dashboard"
+
+class TempleDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    access: Field::String,
+    address: Field::String,
+    areas: Field::HasMany,
+    business_hours: Field::String,
+    description: Field::Text,
+    holiday: Field::String,
+    homepage: Field::String,
+    img: Field::String,
+    latitude: Field::Number.with_options(decimals: 2),
+    longitude: Field::Number.with_options(decimals: 2),
+    name: Field::String,
+    phone_number: Field::String,
+    temple_areas: Field::HasMany,
+    temple_likes: Field::HasMany,
+    users: Field::HasMany,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    access
+    address
+    areas
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    access
+    address
+    areas
+    business_hours
+    description
+    holiday
+    homepage
+    img
+    latitude
+    longitude
+    name
+    phone_number
+    temple_areas
+    temple_likes
+    users
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    access
+    address
+    areas
+    business_hours
+    description
+    holiday
+    homepage
+    img
+    latitude
+    longitude
+    name
+    phone_number
+    temple_areas
+    temple_likes
+    users
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how temples are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(temple)
+  #   "Temple ##{temple.id}"
+  # end
+end

--- a/app/dashboards/temple_like_dashboard.rb
+++ b/app/dashboards/temple_like_dashboard.rb
@@ -1,0 +1,66 @@
+require "administrate/base_dashboard"
+
+class TempleLikeDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    temple: Field::BelongsTo,
+    user: Field::BelongsTo,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    temple
+    user
+    created_at
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    temple
+    user
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    temple
+    user
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how temple likes are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(temple_like)
+  #   "TempleLike ##{temple_like.id}"
+  # end
+end

--- a/app/dashboards/temple_like_dashboard.rb
+++ b/app/dashboards/temple_like_dashboard.rb
@@ -1,4 +1,4 @@
-require "administrate/base_dashboard"
+require 'administrate/base_dashboard'
 
 class TempleLikeDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
@@ -12,7 +12,7 @@ class TempleLikeDashboard < Administrate::BaseDashboard
     temple: Field::BelongsTo,
     user: Field::BelongsTo,
     created_at: Field::DateTime,
-    updated_at: Field::DateTime,
+    updated_at: Field::DateTime
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -1,4 +1,4 @@
-require "administrate/base_dashboard"
+require 'administrate/base_dashboard'
 
 class UserDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
@@ -17,7 +17,7 @@ class UserDashboard < Administrate::BaseDashboard
     temple_likes: Field::HasMany,
     temples: Field::HasMany,
     created_at: Field::DateTime,
-    updated_at: Field::DateTime,
+    updated_at: Field::DateTime
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -1,0 +1,81 @@
+require "administrate/base_dashboard"
+
+class UserDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    authentications: Field::HasMany,
+    greentea_likes: Field::HasMany,
+    greenteas: Field::HasMany,
+    name: Field::String,
+    role: Field::Select.with_options(searchable: false, collection: ->(field) { field.resource.class.send(field.attribute.to_s.pluralize).keys }),
+    temple_likes: Field::HasMany,
+    temples: Field::HasMany,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    authentications
+    greentea_likes
+    greenteas
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    authentications
+    greentea_likes
+    greenteas
+    name
+    role
+    temple_likes
+    temples
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    authentications
+    greentea_likes
+    greenteas
+    name
+    role
+    temple_likes
+    temples
+  ].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how users are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(user)
+  #   "User ##{user.id}"
+  # end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,18 @@
 Rails.application.routes.draw do
+  namespace :admin do
+      resources :users
+      resources :temple_likes
+      resources :temple_areas
+      resources :temples
+      resources :greentea_likes
+      resources :greentea_genres
+      resources :greenteas
+      resources :genres
+      resources :authentications
+      resources :areas
+
+      root to: "users#index"
+    end
 
   root 'static_pages#top'
   get 'terms_of_service', to: 'static_pages#terms_of_service'

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,3 +1,3 @@
 sorcery:
-  twitter_callback_url: 'https://www.matcha-to-jinja.com.com/oauth/callback?provider=twitter'
+  twitter_callback_url: 'https://www.matcha-to-jinja.com/oauth/callback?provider=twitter'
   line_callback_url: 'https://www.matcha-to-jinja.com/oauth/callback?provider=line'

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,3 +1,3 @@
 sorcery:
-  twitter_callback_url: 'https://greentea-temple.herokuapp.com/oauth/callback?provider=twitter'
-  line_callback_url: 'https://greentea-temple.herokuapp.com/oauth/callback?provider=line'
+  twitter_callback_url: 'https://www.matcha-to-jinja.com.com/oauth/callback?provider=twitter'
+  line_callback_url: 'https://www.matcha-to-jinja.com/oauth/callback?provider=line'


### PR DESCRIPTION
## 概要

- 管理画面をgem`administrate`を使用しての再作成
- 独自ドメインを取得したため、SNS認証のコールバックURLを修正
- 他の人のプロフィールページにいけないように修正
<img width="1657" alt="スクリーンショット 2022-11-17 14 11 52" src="https://user-images.githubusercontent.com/94298144/202361722-244e56c6-935b-48ea-8018-f94c265e64f0.png">

## 確認方法

1. Gem を追加したので `bundle install` を実行してください
2. admin権限を持つユーザーしか管理画面にいけないことを確認してください
3. 独自ドメインURLでツイッター、Lineログインが出来ることを確認してください
4. 他の人のプロフィールページにいけないことを確認してください

## 影響範囲

- 管理画面
- app/controllers/users_controller.rb
- config/settings/production.yml

## チェックリスト

- [ ] Lint のチェックをパスした
- [ ] admin権限しか管理画面にアクセスできない
- [ ] 他人のプロフィールページにいけない

## コメント

人のプロフィールページがあることがわかるよりは404エラーにした方が良い為、
次回ハンドリングで修正予定。

Closes #84
