### PR TITLE
docs: CLAUDE.md のデプロイ先と PR ルールを更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,8 @@
 - Administrate（管理画面）
 - Tailwind CSS + daisyUI（jsbundling-rails / cssbundling-rails）
 - RSpec + FactoryBot + Capybara
-- デプロイ: 過去は Heroku 運用だったが、**今後 Heroku にデプロイはしない**。#118 で GCP Cloud Run + Neon へ移行予定。
+- デプロイ: GCP Cloud Run + Neon PostgreSQL（#118 で移行予定）
+  - ⚠️ **Heroku には今後デプロイしない**（過去運用）
 
 外部 API:
 - Google Geocoding API（住所→緯度経度）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@
 - Administrate（管理画面）
 - Tailwind CSS + daisyUI（jsbundling-rails / cssbundling-rails）
 - RSpec + FactoryBot + Capybara
-- Heroku（→ #118 で GCP Cloud Run + Neon へ移行予定）
+- デプロイ: 過去は Heroku 運用だったが、**今後 Heroku にデプロイはしない**。#118 で GCP Cloud Run + Neon へ移行予定。
 
 外部 API:
 - Google Geocoding API（住所→緯度経度）
@@ -44,7 +44,7 @@ bundle exec rubocop
 | `GOOGLE_MAPS_API_KEY` | 地図描画（JS から参照） |
 | `TWITTER_KEY` / `TWITTER_SECRET` | Twitter OAuth |
 | `LINE_KEY` / `LINE_SECRET` | LINE OAuth |
-| `DATABASE_URL` | 本番 PostgreSQL（Heroku → #118 で Neon へ） |
+| `DATABASE_URL` | 本番 PostgreSQL（#118 で Neon へ移行予定） |
 | `FRONTEND_URL` | CORS allowlist。開発: `http://localhost:3000` / 本番: `https://matcha-to-jinja.com`（#113〜） |
 | `JWT_SECRET_KEY` | API 用 JWT 署名（#115〜） |
 | `RAILS_MASTER_KEY` | `credentials.yml.enc` 復号 |
@@ -221,10 +221,11 @@ DELETE /api/v1/greentea_likes/:id     # :id = greentea_id として解決
 ## GitHub PR ルール
 
 - PR 本文は日本語で書く
-- assignee に `hiiragi17` を設定する
+- **assignee に `hiiragi17` を必ず設定する**（PR 作成時に忘れず指定）
 - 関連 issue がある場合は本文に `Closes #<番号>` を含める
 - 1 PR = 1 issue を原則（API 化の親 issue は除く）
 - ブランチ命名: `claude/<task-name>` または `feature/<name>` / `fix/<name>`
+- **Heroku 固有の検証手順（`heroku stack` / `heroku/ruby` buildpack など）は PR 本文に書かない**。今後のデプロイ先は GCP Cloud Run（#118）のため。
 
 ## レビューコメント対応ルール
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,8 @@
 
 ## 技術スタック
 
-- Ruby 3.1.2（→ #119 で 3.3.x へ上げる予定）
-- Ruby on Rails 7.0.3
+- Ruby 3.3.11（#119 で 3.1.2 から上げ済み）
+- Ruby on Rails 7.0.3（→ #124 で 7.1.x へ上げる予定）
 - PostgreSQL
 - Sorcery（Twitter / LINE OAuth）
 - Ransack（検索）/ Kaminari（ページネーション）
@@ -130,7 +130,9 @@ Next.js フロントエンド (matcha-to-jinja) からの参照用に API を実
 依存順:
 
 ```text
-#119 [Ruby 3.1 → 3.3]
+#119 [Ruby 3.1 → 3.3] ✅ merged
+   ↓
+#124 [Rails 7.0 → 7.1 アップグレード]   ← API 化の前に着地
    ↓
 #113 [API 基盤（api/v1 + CORS + Sorcery 0.18 へ更新）]
    ↓
@@ -142,6 +144,11 @@ Next.js フロントエンド (matcha-to-jinja) からの参照用に API を実
         ↓
         #118 [GCP Cloud Run + Neon PostgreSQL + GCS]
 ```
+
+> **#124（Rails アップグレード）を先に着地させる理由**:
+> - Sorcery 0.18 が `railties >= 7.1` を要求し、API で使う認証ライブラリが揃わない
+> - API コードを 7.0 で書いた後に上げると `ActionController::API` / `ErrorReporter` 周りで再回帰が発生する
+> - 詳細は PR #123 のコメント参照
 
 レスポンス契約は matcha-to-jinja 側の `docs/migration-plan.md` の 1-3 を **必ず正**として扱う。
 フロントの mock データ (`src/lib/api/mock/data.ts`) と同じスキーマで返す。


### PR DESCRIPTION
## 概要

ユーザーからの指摘と PR #123 で発覚した依存性問題を受けて CLAUDE.md を更新します。

- **「今後 Heroku にデプロイはしない」**ことを明示。デプロイ先は #118 で GCP Cloud Run + Neon へ移行予定。
- PR 作成時に assignee 指定漏れがあったため、ルールを強調記述に変更。
- 同様に PR 本文に Heroku 固有の検証手順を書かない旨を追記。
- **API 化依存順を更新**: PR #123 で Sorcery 0.18 が Rails 7.1+ を要求することが発覚したため、`#124 (Rails 7.0 → 7.1 アップグレード)` を `#113` の前段に挿入。

## 変更内容

### コミット 1: `0127c36` デプロイ先 + PR ルール

- 技術スタックの「Heroku」項目を「今後デプロイしない」と明示する記述に変更
- 必須環境変数の `DATABASE_URL` 説明から Heroku 参照を削除
- GitHub PR ルールに以下を強調 / 追記:
  - `assignee に hiiragi17 を必ず設定する`（強調）
  - `Heroku 固有の検証手順は PR 本文に書かない`（新規）

### コミット 2: `1c6c9c4` API 化依存順を更新

- 技術スタックの Ruby を 3.3.11（#119 完了済み）に、Rails に #124 アップグレード予定を追記
- 進行中の大型タスクの依存順に **#124（Rails 7.0 → 7.1）** を挿入
- Rails を先に上げる理由（Sorcery 0.18 要件 / API 再回帰回避）を注記

## テストプラン

- [ ] CLAUDE.md の表示を GitHub 上で確認
- [ ] 次回 PR 作成時に新ルールが守られているか確認

## 関連

- 一時停止中の PR: #123
- 新規 issue: #124（Rails 7.0 → 7.1 アップグレード）

https://claude.ai/code/session_01QPM1L5JKgFHyKTK8qRapHL