### PR TITLE
feat: 読み取り系 API エンドポイント実装 (#114)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ gem 'config'
 # CORS for API (#113)
 gem 'rack-cors'
 
+# JSON serializer for API (#114)
+gem 'jsonapi-serializer'
+
 # Localization
 gem 'rails-i18n'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,6 +240,8 @@ GEM
     jsbundling-rails (1.0.3)
       railties (>= 6.0.0)
     json (2.6.2)
+    jsonapi-serializer (2.2.0)
+      activesupport (>= 4.2)
     jwt (3.2.0)
       base64
     kaminari (1.2.2)
@@ -524,6 +526,7 @@ DEPENDENCIES
   gon
   jbuilder
   jsbundling-rails
+  jsonapi-serializer
   kaminari
   meta-tags
   mini_magick

--- a/app/controllers/api/v1/areas_controller.rb
+++ b/app/controllers/api/v1/areas_controller.rb
@@ -1,0 +1,9 @@
+module Api
+  module V1
+    class AreasController < BaseController
+      def index
+        render_simple_collection(Area.order(:id), serializer: AreaSerializer)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -11,7 +11,58 @@ module Api
         render json: { error: 'Not Found' }, status: :not_found
       end
 
+      DEFAULT_PER_PAGE = 15
+      MAX_PER_PAGE = 100
+
       private
+
+      def paginate(scope)
+        per_page = params[:per_page].to_i
+        per_page = DEFAULT_PER_PAGE if per_page <= 0
+        per_page = MAX_PER_PAGE if per_page > MAX_PER_PAGE
+        scope.page(params[:page]).per(per_page)
+      end
+
+      def render_collection(records, serializer:, serializer_params: {})
+        serialized = serializer.new(records.to_a, params: serializer_params).serializable_hash
+        render json: {
+          data: flatten_serialized(serialized[:data]),
+          meta: pagination_meta(records)
+        }
+      end
+
+      def render_simple_collection(records, serializer:, serializer_params: {})
+        serialized = serializer.new(records.to_a, params: serializer_params).serializable_hash
+        render json: { data: flatten_serialized(serialized[:data]) }
+      end
+
+      def render_resource(record, serializer:, serializer_params: {})
+        serialized = serializer.new(record, params: serializer_params).serializable_hash
+        render json: { data: flatten_serialized(serialized[:data]) }
+      end
+
+      def pagination_meta(records)
+        {
+          current_page: records.current_page,
+          total_pages: records.total_pages,
+          total_count: records.total_count,
+          per_page: records.limit_value
+        }
+      end
+
+      def flatten_serialized(data)
+        if data.is_a?(Array)
+          data.map { |d| flatten_one(d) }
+        else
+          flatten_one(data)
+        end
+      end
+
+      def flatten_one(payload)
+        return nil unless payload
+
+        { id: payload[:id].to_i }.merge(payload[:attributes] || {})
+      end
 
       def set_default_format
         request.format = :json

--- a/app/controllers/api/v1/genres_controller.rb
+++ b/app/controllers/api/v1/genres_controller.rb
@@ -1,0 +1,9 @@
+module Api
+  module V1
+    class GenresController < BaseController
+      def index
+        render_simple_collection(Genre.order(:id), serializer: GenreSerializer)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/greenteas_controller.rb
+++ b/app/controllers/api/v1/greenteas_controller.rb
@@ -1,0 +1,41 @@
+module Api
+  module V1
+    class GreenteasController < BaseController
+      def index
+        scope = Greentea.ransack(params[:q]).result(distinct: true).order(:id)
+        paginated = paginate(scope).load
+        like_counts = GreenteaLike.where(greentea_id: paginated.map(&:id)).group(:greentea_id).count
+
+        render_collection(
+          paginated,
+          serializer: GreenteaSerializer,
+          serializer_params: { like_counts: like_counts }
+        )
+      end
+
+      def show
+        greentea = Greentea.includes(:genres).find(params[:id])
+        nearby_temples = nearby_temples_for(greentea)
+
+        render_resource(
+          greentea,
+          serializer: GreenteaDetailSerializer,
+          serializer_params: {
+            like_count: greentea.greentea_likes.size,
+            nearby_temples: nearby_temples
+          }
+        )
+      end
+
+      private
+
+      def nearby_temples_for(greentea)
+        return [] unless greentea.latitude && greentea.longitude
+
+        Temple
+          .within(1.5, origin: [greentea.latitude, greentea.longitude])
+          .by_distance(origin: [greentea.latitude, greentea.longitude])
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/temples_controller.rb
+++ b/app/controllers/api/v1/temples_controller.rb
@@ -1,0 +1,41 @@
+module Api
+  module V1
+    class TemplesController < BaseController
+      def index
+        scope = Temple.ransack(params[:q]).result(distinct: true).order(:id)
+        paginated = paginate(scope).load
+        like_counts = TempleLike.where(temple_id: paginated.map(&:id)).group(:temple_id).count
+
+        render_collection(
+          paginated,
+          serializer: TempleSerializer,
+          serializer_params: { like_counts: like_counts }
+        )
+      end
+
+      def show
+        temple = Temple.includes(:areas).find(params[:id])
+        nearby_greenteas = nearby_greenteas_for(temple)
+
+        render_resource(
+          temple,
+          serializer: TempleDetailSerializer,
+          serializer_params: {
+            like_count: temple.temple_likes.size,
+            nearby_greenteas: nearby_greenteas
+          }
+        )
+      end
+
+      private
+
+      def nearby_greenteas_for(temple)
+        return [] unless temple.latitude && temple.longitude
+
+        Greentea
+          .within(1.5, origin: [temple.latitude, temple.longitude])
+          .by_distance(origin: [temple.latitude, temple.longitude])
+      end
+    end
+  end
+end

--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -3,4 +3,8 @@ class Area < ApplicationRecord
   has_many :temples, through: :temple_areas
 
   validates :name, presence: true
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[id name]
+  end
 end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -3,4 +3,8 @@ class Genre < ApplicationRecord
   has_many :greenteas, through: :greentea_genres
 
   validates :name, presence: true
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[id name]
+  end
 end

--- a/app/models/greentea.rb
+++ b/app/models/greentea.rb
@@ -26,10 +26,10 @@ class Greentea < ApplicationRecord
   end
 
   def self.ransackable_attributes(_auth_object = nil)
-    %w[name address access]
+    %w[name description address access]
   end
 
   def self.ransackable_associations(_auth_object = nil)
-    %w[genres]
+    %w[genres greentea_genres]
   end
 end

--- a/app/models/greentea.rb
+++ b/app/models/greentea.rb
@@ -24,4 +24,12 @@ class Greentea < ApplicationRecord
     distance = distance_to(point) * 1000
     distance.round(-1)
   end
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[name address access]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    %w[genres]
+  end
 end

--- a/app/models/greentea_genre.rb
+++ b/app/models/greentea_genre.rb
@@ -1,4 +1,12 @@
 class GreenteaGenre < ApplicationRecord
   belongs_to :greentea
   belongs_to :genre
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[id greentea_id genre_id]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    %w[greentea genre]
+  end
 end

--- a/app/models/temple.rb
+++ b/app/models/temple.rb
@@ -22,4 +22,12 @@ class Temple < ApplicationRecord
     distance = distance_to(point) * 1000
     distance.round(-1)
   end
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[name address access]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    %w[areas]
+  end
 end

--- a/app/models/temple.rb
+++ b/app/models/temple.rb
@@ -24,10 +24,10 @@ class Temple < ApplicationRecord
   end
 
   def self.ransackable_attributes(_auth_object = nil)
-    %w[name address access]
+    %w[name description address access]
   end
 
   def self.ransackable_associations(_auth_object = nil)
-    %w[areas]
+    %w[areas temple_areas]
   end
 end

--- a/app/models/temple_area.rb
+++ b/app/models/temple_area.rb
@@ -1,4 +1,12 @@
 class TempleArea < ApplicationRecord
   belongs_to :temple
   belongs_to :area
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[id temple_id area_id]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    %w[temple area]
+  end
 end

--- a/app/serializers/api/v1/area_serializer.rb
+++ b/app/serializers/api/v1/area_serializer.rb
@@ -1,0 +1,11 @@
+module Api
+  module V1
+    class AreaSerializer
+      include JSONAPI::Serializer
+
+      set_id { |obj| obj.id }
+
+      attributes :name
+    end
+  end
+end

--- a/app/serializers/api/v1/genre_serializer.rb
+++ b/app/serializers/api/v1/genre_serializer.rb
@@ -1,0 +1,11 @@
+module Api
+  module V1
+    class GenreSerializer
+      include JSONAPI::Serializer
+
+      set_id { |obj| obj.id }
+
+      attributes :name
+    end
+  end
+end

--- a/app/serializers/api/v1/greentea_detail_serializer.rb
+++ b/app/serializers/api/v1/greentea_detail_serializer.rb
@@ -1,0 +1,31 @@
+module Api
+  module V1
+    class GreenteaDetailSerializer
+      include JSONAPI::Serializer
+
+      set_id { |obj| obj.id }
+
+      attributes :name, :description, :address, :access, :business_hours,
+                 :holiday, :phone_number, :homepage, :latitude, :longitude, :img
+
+      attribute :like_count do |obj, params|
+        params[:like_count] || obj.greentea_likes.size
+      end
+
+      attribute :liked_by_current_user do |_obj, _params|
+        false
+      end
+
+      attribute :genres do |obj|
+        obj.genres.map { |g| { id: g.id, name: g.name } }
+      end
+
+      attribute :nearby_temples do |obj, params|
+        nearby = params[:nearby_temples] || []
+        origin = [obj.latitude, obj.longitude]
+        serialized = NearbyTempleSerializer.new(nearby, params: { origin: origin }).serializable_hash[:data]
+        serialized.map { |d| { id: d[:id].to_i, **d[:attributes] } }
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/greentea_serializer.rb
+++ b/app/serializers/api/v1/greentea_serializer.rb
@@ -1,0 +1,20 @@
+module Api
+  module V1
+    class GreenteaSerializer
+      include JSONAPI::Serializer
+
+      set_id { |obj| obj.id }
+
+      attributes :name, :address, :access, :business_hours, :holiday,
+                 :latitude, :longitude, :img
+
+      attribute :like_count do |obj, params|
+        params[:like_counts]&.fetch(obj.id, 0) || 0
+      end
+
+      attribute :liked_by_current_user do |_obj, _params|
+        false
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/nearby_greentea_serializer.rb
+++ b/app/serializers/api/v1/nearby_greentea_serializer.rb
@@ -1,0 +1,20 @@
+module Api
+  module V1
+    class NearbyGreenteaSerializer
+      include JSONAPI::Serializer
+
+      set_id { |obj| obj.id }
+
+      attributes :name, :latitude, :longitude
+
+      attribute :distance_meters do |obj, params|
+        origin = params[:origin]
+        if origin
+          obj.get_distance(origin[0], origin[1])
+        elsif obj.respond_to?(:distance) && obj.distance
+          (obj.distance.to_f * 1000).round
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/nearby_temple_serializer.rb
+++ b/app/serializers/api/v1/nearby_temple_serializer.rb
@@ -1,0 +1,20 @@
+module Api
+  module V1
+    class NearbyTempleSerializer
+      include JSONAPI::Serializer
+
+      set_id { |obj| obj.id }
+
+      attributes :name, :latitude, :longitude
+
+      attribute :distance_meters do |obj, params|
+        origin = params[:origin]
+        if origin
+          obj.get_distance(origin[0], origin[1])
+        elsif obj.respond_to?(:distance) && obj.distance
+          (obj.distance.to_f * 1000).round
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/temple_detail_serializer.rb
+++ b/app/serializers/api/v1/temple_detail_serializer.rb
@@ -1,0 +1,31 @@
+module Api
+  module V1
+    class TempleDetailSerializer
+      include JSONAPI::Serializer
+
+      set_id { |obj| obj.id }
+
+      attributes :name, :description, :address, :access, :business_hours,
+                 :holiday, :phone_number, :homepage, :latitude, :longitude, :img
+
+      attribute :like_count do |obj, params|
+        params[:like_count] || obj.temple_likes.size
+      end
+
+      attribute :liked_by_current_user do |_obj, _params|
+        false
+      end
+
+      attribute :areas do |obj|
+        obj.areas.map { |a| { id: a.id, name: a.name } }
+      end
+
+      attribute :nearby_greenteas do |obj, params|
+        nearby = params[:nearby_greenteas] || []
+        origin = [obj.latitude, obj.longitude]
+        serialized = NearbyGreenteaSerializer.new(nearby, params: { origin: origin }).serializable_hash[:data]
+        serialized.map { |d| { id: d[:id].to_i, **d[:attributes] } }
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/temple_serializer.rb
+++ b/app/serializers/api/v1/temple_serializer.rb
@@ -1,0 +1,20 @@
+module Api
+  module V1
+    class TempleSerializer
+      include JSONAPI::Serializer
+
+      set_id { |obj| obj.id }
+
+      attributes :name, :address, :access, :business_hours, :holiday,
+                 :latitude, :longitude, :img
+
+      attribute :like_count do |obj, params|
+        params[:like_counts]&.fetch(obj.id, 0) || 0
+      end
+
+      attribute :liked_by_current_user do |_obj, _params|
+        false
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,11 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get 'health', to: 'health#show'
+
+      resources :greenteas, only: %i[index show]
+      resources :temples, only: %i[index show]
+      resources :genres, only: %i[index]
+      resources :areas, only: %i[index]
     end
 
     match '*unmatched', to: 'v1/base#route_not_found', via: :all

--- a/spec/requests/api/v1/areas_spec.rb
+++ b/spec/requests/api/v1/areas_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Areas', type: :request do
+  describe 'GET /api/v1/areas' do
+    let!(:areas) { create_list(:area, 2) }
+
+    it 'returns 200 with all areas' do
+      get '/api/v1/areas'
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json['data'].size).to eq(2)
+      expect(json['data'].first).to include('id', 'name')
+      expect(json['data'].first['id']).to be_a(Integer)
+    end
+  end
+end

--- a/spec/requests/api/v1/genres_spec.rb
+++ b/spec/requests/api/v1/genres_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Genres', type: :request do
+  describe 'GET /api/v1/genres' do
+    let!(:genres) { create_list(:genre, 2) }
+
+    it 'returns 200 with all genres' do
+      get '/api/v1/genres'
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json['data'].size).to eq(2)
+      expect(json['data'].first).to include('id', 'name')
+      expect(json['data'].first['id']).to be_a(Integer)
+    end
+  end
+end

--- a/spec/requests/api/v1/greenteas_spec.rb
+++ b/spec/requests/api/v1/greenteas_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Greenteas', type: :request do
+  describe 'GET /api/v1/greenteas' do
+    let!(:greenteas) { create_list(:greentea, 3) }
+
+    it 'returns 200 with data and meta' do
+      get '/api/v1/greenteas'
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json['data']).to be_an(Array)
+      expect(json['data'].size).to eq(3)
+      expect(json['meta']).to include(
+        'current_page' => 1,
+        'total_count' => 3,
+        'per_page' => 15
+      )
+      expect(json['meta']['total_pages']).to eq(1)
+    end
+
+    it 'returns flat snake_case spot fields' do
+      get '/api/v1/greenteas'
+
+      attrs = response.parsed_body['data'].first
+      expect(attrs).to include(
+        'id', 'name', 'address', 'access', 'business_hours', 'holiday',
+        'latitude', 'longitude', 'img', 'like_count', 'liked_by_current_user'
+      )
+      expect(attrs['id']).to be_a(Integer)
+      expect(attrs['liked_by_current_user']).to eq(false)
+    end
+
+    it 'paginates with page / per_page params' do
+      get '/api/v1/greenteas', params: { per_page: 2, page: 2 }
+
+      json = response.parsed_body
+      expect(json['data'].size).to eq(1)
+      expect(json['meta']).to include('current_page' => 2, 'total_pages' => 2, 'per_page' => 2)
+    end
+
+    it 'filters by q[name_cont] (Ransack allowlist)' do
+      target = create(:greentea, name: '宇治抹茶パフェ専門店')
+
+      get '/api/v1/greenteas', params: { q: { name_cont: '宇治抹茶' } }
+
+      ids = response.parsed_body['data'].map { |d| d['id'] }
+      expect(ids).to eq([target.id])
+    end
+
+    it 'filters by q[genres_id_eq]' do
+      genre = create(:genre)
+      target = create(:greentea)
+      create(:greentea_genre, greentea: target, genre: genre)
+
+      get '/api/v1/greenteas', params: { q: { genres_id_eq: genre.id } }
+
+      ids = response.parsed_body['data'].map { |d| d['id'] }
+      expect(ids).to eq([target.id])
+    end
+
+    it 'returns like_count aggregated per record' do
+      liked = greenteas.first
+      user_a = User.create!(name: 'A')
+      user_b = User.create!(name: 'B')
+      GreenteaLike.create!(user: user_a, greentea: liked)
+      GreenteaLike.create!(user: user_b, greentea: liked)
+
+      get '/api/v1/greenteas'
+
+      payload = response.parsed_body['data'].find { |d| d['id'] == liked.id }
+      expect(payload['like_count']).to eq(2)
+    end
+  end
+
+  describe 'GET /api/v1/greenteas/:id' do
+    let(:greentea) { create(:greentea, latitude: 34.9676, longitude: 135.7741) }
+
+    it 'returns 200 with detail fields' do
+      get "/api/v1/greenteas/#{greentea.id}"
+
+      expect(response).to have_http_status(:ok)
+      attrs = response.parsed_body['data']
+      expect(attrs).to include(
+        'id', 'name', 'description', 'address', 'access', 'business_hours',
+        'holiday', 'phone_number', 'homepage', 'latitude', 'longitude', 'img',
+        'like_count', 'liked_by_current_user', 'genres', 'nearby_temples'
+      )
+      expect(attrs['id']).to eq(greentea.id)
+    end
+
+    it 'includes nearby_temples sorted by distance ascending' do
+      near = create(:temple, latitude: 34.96770, longitude: 135.77410)
+      mid  = create(:temple, latitude: 34.96900, longitude: 135.77410)
+
+      get "/api/v1/greenteas/#{greentea.id}"
+
+      nearby = response.parsed_body['data']['nearby_temples']
+      expect(nearby.map { |t| t['id'] }).to eq([near.id, mid.id])
+      nearby.each do |t|
+        expect(t).to include('id', 'name', 'latitude', 'longitude', 'distance_meters')
+        expect(t['distance_meters']).to be_a(Integer)
+      end
+      distances = nearby.map { |t| t['distance_meters'] }
+      expect(distances).to eq(distances.sort)
+    end
+
+    it 'returns 404 for missing id' do
+      get '/api/v1/greenteas/999999'
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq('error' => 'Not Found')
+    end
+  end
+end

--- a/spec/requests/api/v1/greenteas_spec.rb
+++ b/spec/requests/api/v1/greenteas_spec.rb
@@ -59,6 +59,27 @@ RSpec.describe 'Api::V1::Greenteas', type: :request do
       expect(ids).to eq([target.id])
     end
 
+    # Web 既存検索フォームの ransack キーが allowlist で通ることの回帰テスト
+    it 'accepts q[name_or_description_or_address_or_access_cont] (legacy web key)' do
+      target = create(:greentea, description: 'とろける宇治抹茶のティラミス')
+
+      get '/api/v1/greenteas', params: { q: { name_or_description_or_address_or_access_cont: 'とろける宇治抹茶' } }
+
+      ids = response.parsed_body['data'].map { |d| d['id'] }
+      expect(ids).to eq([target.id])
+    end
+
+    it 'accepts q[greentea_genres_genre_id_eq_any] (legacy web key)' do
+      genre = create(:genre)
+      target = create(:greentea)
+      create(:greentea_genre, greentea: target, genre: genre)
+
+      get '/api/v1/greenteas', params: { q: { greentea_genres_genre_id_eq_any: [genre.id] } }
+
+      ids = response.parsed_body['data'].map { |d| d['id'] }
+      expect(ids).to eq([target.id])
+    end
+
     it 'returns like_count aggregated per record' do
       liked = greenteas.first
       user_a = User.create!(name: 'A')

--- a/spec/requests/api/v1/temples_spec.rb
+++ b/spec/requests/api/v1/temples_spec.rb
@@ -37,6 +37,27 @@ RSpec.describe 'Api::V1::Temples', type: :request do
       ids = response.parsed_body['data'].map { |d| d['id'] }
       expect(ids).to eq([target.id])
     end
+
+    # Web 既存検索フォームの ransack キーが allowlist で通ることの回帰テスト
+    it 'accepts q[name_or_description_or_address_or_access_cont] (legacy web key)' do
+      target = create(:temple, description: '紅葉の名所として知られる古刹')
+
+      get '/api/v1/temples', params: { q: { name_or_description_or_address_or_access_cont: '紅葉の名所' } }
+
+      ids = response.parsed_body['data'].map { |d| d['id'] }
+      expect(ids).to eq([target.id])
+    end
+
+    it 'accepts q[temple_areas_area_id_eq_any] (legacy web key)' do
+      area = create(:area)
+      target = create(:temple)
+      create(:temple_area, temple: target, area: area)
+
+      get '/api/v1/temples', params: { q: { temple_areas_area_id_eq_any: [area.id] } }
+
+      ids = response.parsed_body['data'].map { |d| d['id'] }
+      expect(ids).to eq([target.id])
+    end
   end
 
   describe 'GET /api/v1/temples/:id' do

--- a/spec/requests/api/v1/temples_spec.rb
+++ b/spec/requests/api/v1/temples_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Temples', type: :request do
+  describe 'GET /api/v1/temples' do
+    let!(:temples) { create_list(:temple, 3) }
+
+    it 'returns 200 with data and meta' do
+      get '/api/v1/temples'
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json['data'].size).to eq(3)
+      expect(json['meta']).to include(
+        'current_page' => 1,
+        'total_count' => 3,
+        'per_page' => 15
+      )
+    end
+
+    it 'returns flat snake_case spot fields' do
+      get '/api/v1/temples'
+
+      attrs = response.parsed_body['data'].first
+      expect(attrs).to include(
+        'id', 'name', 'address', 'access', 'business_hours', 'holiday',
+        'latitude', 'longitude', 'img', 'like_count', 'liked_by_current_user'
+      )
+    end
+
+    it 'filters by q[areas_id_eq]' do
+      area = create(:area)
+      target = create(:temple)
+      create(:temple_area, temple: target, area: area)
+
+      get '/api/v1/temples', params: { q: { areas_id_eq: area.id } }
+
+      ids = response.parsed_body['data'].map { |d| d['id'] }
+      expect(ids).to eq([target.id])
+    end
+  end
+
+  describe 'GET /api/v1/temples/:id' do
+    let(:temple) { create(:temple, latitude: 34.9676, longitude: 135.7741) }
+
+    it 'returns 200 with detail fields and nearby_greenteas' do
+      near = create(:greentea, latitude: 34.96770, longitude: 135.77410)
+
+      get "/api/v1/temples/#{temple.id}"
+
+      expect(response).to have_http_status(:ok)
+      attrs = response.parsed_body['data']
+      expect(attrs).to include(
+        'id', 'name', 'description', 'address', 'access', 'business_hours',
+        'holiday', 'phone_number', 'homepage', 'latitude', 'longitude', 'img',
+        'like_count', 'liked_by_current_user', 'areas', 'nearby_greenteas'
+      )
+      expect(attrs['nearby_greenteas'].map { |g| g['id'] }).to include(near.id)
+      attrs['nearby_greenteas'].each do |g|
+        expect(g).to include('id', 'name', 'latitude', 'longitude', 'distance_meters')
+        expect(g['distance_meters']).to be_a(Integer)
+      end
+    end
+
+    it 'returns 404 for missing id' do
+      get '/api/v1/temples/999999'
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
## 概要

API 化 (#113) の上に乗る **読み取り系 API** を実装しました。
これにより matcha-to-jinja フロントの `NEXT_PUBLIC_USE_MOCK=false` への切替が可能になります。

Closes #114

## 追加エンドポイント

| Method | Path | 用途 |
|---|---|---|
| GET | `/api/v1/greenteas` | 抹茶店一覧（Ransack + Kaminari） |
| GET | `/api/v1/greenteas/:id` | 詳細 + `nearby_temples`（1.5km 圏内、距離昇順） |
| GET | `/api/v1/temples` | 神社仏閣一覧 |
| GET | `/api/v1/temples/:id` | 詳細 + `nearby_greenteas` |
| GET | `/api/v1/genres` | ジャンル一覧 |
| GET | `/api/v1/areas` | エリア一覧 |

## 主な変更点

### Serializer 基盤
- `jsonapi-serializer` を導入（CLAUDE.md の方針に従う）
- `Api::V1::BaseController` に `paginate` / `render_collection` / `render_resource` ヘルパーを追加
- jsonapi-serializer の `{ data: { id, attributes } }` 形式を **snake_case のフラット形式** に整形（フロント mock と同スキーマ）
- 一覧は `meta: { current_page, total_pages, total_count, per_page }` を共通付与
- `per_page` は `params[:per_page]` を 1〜100 にクランプ

### Ransack
- `Greentea` / `Temple` / `Genre` / `Area` に `ransackable_attributes` / `ransackable_associations` を **allowlist で明示**
- サポートする検索キー: `q[name_cont]` / `q[genres_id_eq]`（抹茶店）/ `q[areas_id_eq]`（神社）

### 詳細レスポンス
- `nearby_temples` / `nearby_greenteas` を専用 serializer に切り出し（CLAUDE.md 規約に従う）
- `distance_meters` はモデルの `get_distance` を使い整数で返却
- 距離は `Geokit::LatLng#distance_to * 1000` ベース（CLAUDE.md 規約）

### like_count / liked_by_current_user
- `like_count` は中間テーブルに対する `GROUP BY` 1 本で集計（N+1 回避）
- `liked_by_current_user` は **#116 (JWT 認証 + いいね API) の着地までは `false` 固定**

### レスポンス例

```json
GET /api/v1/greenteas
{
  "data": [
    {
      "id": 1,
      "name": "...",
      "address": "...",
      "access": "...",
      "business_hours": "...",
      "holiday": "...",
      "latitude": 34.9676,
      "longitude": 135.7741,
      "img": "...",
      "like_count": 2,
      "liked_by_current_user": false
    }
  ],
  "meta": { "current_page": 1, "total_pages": 5, "total_count": 70, "per_page": 15 }
}
```

```json
GET /api/v1/greenteas/:id
{
  "data": {
    "id": 1, "name": "...", "description": "...", ...
    "genres": [{ "id": 3, "name": "パフェ" }],
    "nearby_temples": [
      { "id": 4, "name": "...", "latitude": ..., "longitude": ..., "distance_meters": 450 }
    ]
  }
}
```

## テスト

`spec/requests/api/v1/` に request spec を追加:

- [x] 一覧 / 詳細の正常系（フィールド整合）
- [x] Ransack 検索（`name_cont` / `genres_id_eq` / `areas_id_eq`）
- [x] ページネーション（`per_page` / `page` / `meta`）
- [x] `like_count` 集計
- [x] `nearby_temples` の距離昇順
- [x] 404 (`/greenteas/999999`)

> **ローカル検証について**: 本コンテナに Ruby 3.3.11 が無く `bundle install` / `rspec` をローカル実行できなかったため、構文チェックのみ実施。CI または手元の 3.3.11 環境で `bundle exec rspec spec/requests/api/v1/` の実行をお願いします。

## 動作確認手順（フロント結合）

1. 本ブランチを pull
2. `bundle install`
3. `bin/rails server -p 3001`
4. matcha-to-jinja 側で `NEXT_PUBLIC_USE_MOCK=false NEXT_PUBLIC_API_URL=http://localhost:3001 yarn dev`
5. 一覧 / 詳細 / 検索 / ページネーションがフロントから動作することを確認

## 残タスク（このPRのスコープ外）

- `liked_by_current_user` の実値化 → **#116**（JWT 認証の上に乗せる）
- いいね・コメント API → **#116**
- 近隣検索 API (`/api/v1/nearby`) → **#117**

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGqMNUd9VWN7LwMWbvxutf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added REST API endpoints for browsing greenteas and temples with search/filtering and pagination
* Added API endpoints for viewing genres and areas
* Implemented like counts for greenteas and temples
* Location-based discovery: find nearby temples when exploring greenteas and nearby greenteas when exploring temples, with distance metrics

**Tests**
* Added comprehensive test coverage for new API endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->