### PR TITLE
feat: 読み取り系 API エンドポイント実装 (#114) — レビュー反映版

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ gem 'config'
 # CORS for API (#113)
 gem 'rack-cors'
 
+# JSON serializer for API (#114)
+gem 'jsonapi-serializer', '~> 2.2'
+
 # Localization
 gem 'rails-i18n'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,6 +240,8 @@ GEM
     jsbundling-rails (1.0.3)
       railties (>= 6.0.0)
     json (2.6.2)
+    jsonapi-serializer (2.2.0)
+      activesupport (>= 4.2)
     jwt (3.2.0)
       base64
     kaminari (1.2.2)
@@ -524,6 +526,7 @@ DEPENDENCIES
   gon
   jbuilder
   jsbundling-rails
+  jsonapi-serializer (~> 2.2)
   kaminari
   meta-tags
   mini_magick

--- a/app/controllers/api/v1/areas_controller.rb
+++ b/app/controllers/api/v1/areas_controller.rb
@@ -1,0 +1,9 @@
+module Api
+  module V1
+    class AreasController < BaseController
+      def index
+        render_collection(paginate(Area.order(:id)), serializer: AreaSerializer)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,6 +1,9 @@
 module Api
   module V1
     class BaseController < ActionController::API
+      DEFAULT_PER_PAGE = 15
+      MAX_PER_PAGE = 100
+
       before_action :set_default_format
 
       rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
@@ -12,6 +15,49 @@ module Api
       end
 
       private
+
+      def paginate(scope)
+        per_page = params[:per_page].to_i
+        per_page = DEFAULT_PER_PAGE if per_page <= 0
+        per_page = MAX_PER_PAGE if per_page > MAX_PER_PAGE
+        scope.page(params[:page]).per(per_page)
+      end
+
+      def render_collection(records, serializer:, serializer_params: {})
+        serialized = serializer.new(records.to_a, params: serializer_params).serializable_hash
+        render json: {
+          data: flatten_serialized(serialized[:data]),
+          meta: pagination_meta(records)
+        }
+      end
+
+      def render_resource(record, serializer:, serializer_params: {})
+        serialized = serializer.new(record, params: serializer_params).serializable_hash
+        render json: { data: flatten_serialized(serialized[:data]) }
+      end
+
+      def pagination_meta(records)
+        {
+          current_page: records.current_page,
+          total_pages: records.total_pages,
+          total_count: records.total_count,
+          per_page: records.limit_value
+        }
+      end
+
+      def flatten_serialized(data)
+        if data.is_a?(Array)
+          data.map { |d| flatten_one(d) }
+        else
+          flatten_one(data)
+        end
+      end
+
+      def flatten_one(payload)
+        return nil unless payload
+
+        { id: payload[:id].to_i }.merge(payload[:attributes] || {})
+      end
 
       def set_default_format
         request.format = :json

--- a/app/controllers/api/v1/genres_controller.rb
+++ b/app/controllers/api/v1/genres_controller.rb
@@ -1,0 +1,9 @@
+module Api
+  module V1
+    class GenresController < BaseController
+      def index
+        render_collection(paginate(Genre.order(:id)), serializer: GenreSerializer)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/greenteas_controller.rb
+++ b/app/controllers/api/v1/greenteas_controller.rb
@@ -1,0 +1,41 @@
+module Api
+  module V1
+    class GreenteasController < BaseController
+      def index
+        scope = Greentea.ransack(params[:q]).result(distinct: true).order(:id)
+        paginated = paginate(scope).load
+        like_counts = GreenteaLike.where(greentea_id: paginated.map(&:id)).group(:greentea_id).count
+
+        render_collection(
+          paginated,
+          serializer: GreenteaSerializer,
+          serializer_params: { like_counts: like_counts }
+        )
+      end
+
+      def show
+        greentea = Greentea.includes(:genres).find(params[:id])
+        nearby_temples = nearby_temples_for(greentea)
+
+        render_resource(
+          greentea,
+          serializer: GreenteaDetailSerializer,
+          serializer_params: {
+            like_count: greentea.greentea_likes.size,
+            nearby_temples: nearby_temples
+          }
+        )
+      end
+
+      private
+
+      def nearby_temples_for(greentea)
+        return [] unless greentea.latitude && greentea.longitude
+
+        Temple
+          .within(1.5, origin: [greentea.latitude, greentea.longitude])
+          .by_distance(origin: [greentea.latitude, greentea.longitude])
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/temples_controller.rb
+++ b/app/controllers/api/v1/temples_controller.rb
@@ -1,0 +1,41 @@
+module Api
+  module V1
+    class TemplesController < BaseController
+      def index
+        scope = Temple.ransack(params[:q]).result(distinct: true).order(:id)
+        paginated = paginate(scope).load
+        like_counts = TempleLike.where(temple_id: paginated.map(&:id)).group(:temple_id).count
+
+        render_collection(
+          paginated,
+          serializer: TempleSerializer,
+          serializer_params: { like_counts: like_counts }
+        )
+      end
+
+      def show
+        temple = Temple.includes(:areas).find(params[:id])
+        nearby_greenteas = nearby_greenteas_for(temple)
+
+        render_resource(
+          temple,
+          serializer: TempleDetailSerializer,
+          serializer_params: {
+            like_count: temple.temple_likes.size,
+            nearby_greenteas: nearby_greenteas
+          }
+        )
+      end
+
+      private
+
+      def nearby_greenteas_for(temple)
+        return [] unless temple.latitude && temple.longitude
+
+        Greentea
+          .within(1.5, origin: [temple.latitude, temple.longitude])
+          .by_distance(origin: [temple.latitude, temple.longitude])
+      end
+    end
+  end
+end

--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -3,4 +3,12 @@ class Area < ApplicationRecord
   has_many :temples, through: :temple_areas
 
   validates :name, presence: true
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[id name]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    []
+  end
 end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -3,4 +3,12 @@ class Genre < ApplicationRecord
   has_many :greenteas, through: :greentea_genres
 
   validates :name, presence: true
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[id name]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    []
+  end
 end

--- a/app/models/greentea.rb
+++ b/app/models/greentea.rb
@@ -24,4 +24,12 @@ class Greentea < ApplicationRecord
     distance = distance_to(point) * 1000
     distance.round(-1)
   end
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[name description address access]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    %w[genres greentea_genres]
+  end
 end

--- a/app/models/greentea_genre.rb
+++ b/app/models/greentea_genre.rb
@@ -1,4 +1,12 @@
 class GreenteaGenre < ApplicationRecord
   belongs_to :greentea
   belongs_to :genre
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[id greentea_id genre_id]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    %w[greentea genre]
+  end
 end

--- a/app/models/temple.rb
+++ b/app/models/temple.rb
@@ -22,4 +22,12 @@ class Temple < ApplicationRecord
     distance = distance_to(point) * 1000
     distance.round(-1)
   end
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[name description address access]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    %w[areas temple_areas]
+  end
 end

--- a/app/models/temple_area.rb
+++ b/app/models/temple_area.rb
@@ -1,4 +1,12 @@
 class TempleArea < ApplicationRecord
   belongs_to :temple
   belongs_to :area
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[id temple_id area_id]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    %w[temple area]
+  end
 end

--- a/app/serializers/api/v1/area_serializer.rb
+++ b/app/serializers/api/v1/area_serializer.rb
@@ -1,0 +1,9 @@
+module Api
+  module V1
+    class AreaSerializer
+      include JSONAPI::Serializer
+
+      attributes :name
+    end
+  end
+end

--- a/app/serializers/api/v1/genre_serializer.rb
+++ b/app/serializers/api/v1/genre_serializer.rb
@@ -1,0 +1,9 @@
+module Api
+  module V1
+    class GenreSerializer
+      include JSONAPI::Serializer
+
+      attributes :name
+    end
+  end
+end

--- a/app/serializers/api/v1/greentea_detail_serializer.rb
+++ b/app/serializers/api/v1/greentea_detail_serializer.rb
@@ -1,0 +1,30 @@
+module Api
+  module V1
+    class GreenteaDetailSerializer
+      include JSONAPI::Serializer
+
+      attributes :name, :description, :address, :access, :business_hours,
+                 :holiday, :phone_number, :homepage, :latitude, :longitude, :img
+
+      attribute :like_count do |obj, params|
+        params[:like_count] || obj.greentea_likes.size
+      end
+
+      attribute :liked_by_current_user do |_obj, _params|
+        false
+      end
+
+      attribute :genres do |obj|
+        obj.genres.map { |g| { id: g.id, name: g.name } }
+      end
+
+      attribute :nearby_temples do |obj, params|
+        nearby = params[:nearby_temples] || []
+        serializer_params = {}
+        serializer_params[:origin] = [obj.latitude, obj.longitude] if obj.latitude && obj.longitude
+        serialized = NearbyTempleSerializer.new(nearby, params: serializer_params).serializable_hash[:data] || []
+        serialized.map { |d| { id: d[:id].to_i, **d[:attributes] } }
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/greentea_serializer.rb
+++ b/app/serializers/api/v1/greentea_serializer.rb
@@ -1,0 +1,18 @@
+module Api
+  module V1
+    class GreenteaSerializer
+      include JSONAPI::Serializer
+
+      attributes :name, :address, :access, :business_hours, :holiday,
+                 :latitude, :longitude, :img
+
+      attribute :like_count do |obj, params|
+        params[:like_counts]&.fetch(obj.id, 0) || 0
+      end
+
+      attribute :liked_by_current_user do |_obj, _params|
+        false
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/nearby_greentea_serializer.rb
+++ b/app/serializers/api/v1/nearby_greentea_serializer.rb
@@ -1,0 +1,20 @@
+module Api
+  module V1
+    class NearbyGreenteaSerializer
+      include JSONAPI::Serializer
+
+      attributes :name, :latitude, :longitude
+
+      attribute :distance_meters do |obj, params|
+        if obj.respond_to?(:distance) && obj.distance
+          (obj.distance.to_f * 1000).round
+        else
+          origin = params[:origin]
+          if origin && origin[0] && origin[1]
+            obj.get_distance(origin[0], origin[1])
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/nearby_temple_serializer.rb
+++ b/app/serializers/api/v1/nearby_temple_serializer.rb
@@ -1,0 +1,20 @@
+module Api
+  module V1
+    class NearbyTempleSerializer
+      include JSONAPI::Serializer
+
+      attributes :name, :latitude, :longitude
+
+      attribute :distance_meters do |obj, params|
+        if obj.respond_to?(:distance) && obj.distance
+          (obj.distance.to_f * 1000).round
+        else
+          origin = params[:origin]
+          if origin && origin[0] && origin[1]
+            obj.get_distance(origin[0], origin[1])
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/temple_detail_serializer.rb
+++ b/app/serializers/api/v1/temple_detail_serializer.rb
@@ -1,0 +1,30 @@
+module Api
+  module V1
+    class TempleDetailSerializer
+      include JSONAPI::Serializer
+
+      attributes :name, :description, :address, :access, :business_hours,
+                 :holiday, :phone_number, :homepage, :latitude, :longitude, :img
+
+      attribute :like_count do |obj, params|
+        params[:like_count] || obj.temple_likes.size
+      end
+
+      attribute :liked_by_current_user do |_obj, _params|
+        false
+      end
+
+      attribute :areas do |obj|
+        obj.areas.map { |a| { id: a.id, name: a.name } }
+      end
+
+      attribute :nearby_greenteas do |obj, params|
+        nearby = params[:nearby_greenteas] || []
+        serializer_params = {}
+        serializer_params[:origin] = [obj.latitude, obj.longitude] if obj.latitude && obj.longitude
+        serialized = NearbyGreenteaSerializer.new(nearby, params: serializer_params).serializable_hash[:data] || []
+        serialized.map { |d| { id: d[:id].to_i, **d[:attributes] } }
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/temple_serializer.rb
+++ b/app/serializers/api/v1/temple_serializer.rb
@@ -1,0 +1,18 @@
+module Api
+  module V1
+    class TempleSerializer
+      include JSONAPI::Serializer
+
+      attributes :name, :address, :access, :business_hours, :holiday,
+                 :latitude, :longitude, :img
+
+      attribute :like_count do |obj, params|
+        params[:like_counts]&.fetch(obj.id, 0) || 0
+      end
+
+      attribute :liked_by_current_user do |_obj, _params|
+        false
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,11 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get 'health', to: 'health#show'
+
+      resources :greenteas, only: %i[index show]
+      resources :temples, only: %i[index show]
+      resources :genres, only: %i[index]
+      resources :areas, only: %i[index]
     end
 
     match '*unmatched', to: 'v1/base#route_not_found', via: :all

--- a/spec/requests/api/v1/areas_spec.rb
+++ b/spec/requests/api/v1/areas_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'Api::V1::Areas', type: :request do
 
       expect(response.parsed_body['meta']).to include(
         'current_page' => 1,
+        'total_pages' => 1,
         'total_count' => 2,
         'per_page' => 15
       )

--- a/spec/requests/api/v1/areas_spec.rb
+++ b/spec/requests/api/v1/areas_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Areas', type: :request do
+  describe 'GET /api/v1/areas' do
+    let!(:areas) { create_list(:area, 2) }
+
+    it 'returns 200 with all areas' do
+      get '/api/v1/areas'
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json['data'].size).to eq(2)
+      expect(json['data'].first).to include('id', 'name')
+      expect(json['data'].first['id']).to be_a(Integer)
+    end
+
+    it 'orders areas by id ascending' do
+      get '/api/v1/areas'
+
+      ids = response.parsed_body['data'].map { |a| a['id'] }
+      expect(ids).to eq(ids.sort)
+    end
+
+    it 'includes pagination meta' do
+      get '/api/v1/areas'
+
+      expect(response.parsed_body['meta']).to include(
+        'current_page' => 1,
+        'total_count' => 2,
+        'per_page' => 15
+      )
+    end
+  end
+end

--- a/spec/requests/api/v1/genres_spec.rb
+++ b/spec/requests/api/v1/genres_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Genres', type: :request do
+  describe 'GET /api/v1/genres' do
+    let!(:genres) { create_list(:genre, 2) }
+
+    it 'returns 200 with all genres' do
+      get '/api/v1/genres'
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json['data'].size).to eq(2)
+      expect(json['data'].first).to include('id', 'name')
+      expect(json['data'].first['id']).to be_a(Integer)
+    end
+
+    it 'orders genres by id ascending' do
+      get '/api/v1/genres'
+
+      ids = response.parsed_body['data'].map { |g| g['id'] }
+      expect(ids).to eq(ids.sort)
+    end
+
+    it 'includes pagination meta' do
+      get '/api/v1/genres'
+
+      expect(response.parsed_body['meta']).to include(
+        'current_page' => 1,
+        'total_count' => 2,
+        'per_page' => 15
+      )
+    end
+  end
+end

--- a/spec/requests/api/v1/genres_spec.rb
+++ b/spec/requests/api/v1/genres_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'Api::V1::Genres', type: :request do
 
       expect(response.parsed_body['meta']).to include(
         'current_page' => 1,
+        'total_pages' => 1,
         'total_count' => 2,
         'per_page' => 15
       )

--- a/spec/requests/api/v1/greenteas_spec.rb
+++ b/spec/requests/api/v1/greenteas_spec.rb
@@ -1,0 +1,143 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Greenteas', type: :request do
+  describe 'GET /api/v1/greenteas' do
+    let!(:greenteas) { create_list(:greentea, 3) }
+
+    it 'returns 200 with data and meta' do
+      get '/api/v1/greenteas'
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json['data']).to be_an(Array)
+      expect(json['data'].size).to eq(3)
+      expect(json['meta']).to include(
+        'current_page' => 1,
+        'total_count' => 3,
+        'per_page' => 15
+      )
+      expect(json['meta']['total_pages']).to eq(1)
+    end
+
+    it 'returns flat snake_case spot fields' do
+      get '/api/v1/greenteas'
+
+      attrs = response.parsed_body['data'].first
+      expect(attrs).to include(
+        'id', 'name', 'address', 'access', 'business_hours', 'holiday',
+        'latitude', 'longitude', 'img', 'like_count', 'liked_by_current_user'
+      )
+      expect(attrs['id']).to be_a(Integer)
+      expect(attrs['liked_by_current_user']).to eq(false)
+    end
+
+    it 'paginates with page / per_page params' do
+      get '/api/v1/greenteas', params: { per_page: 2, page: 2 }
+
+      json = response.parsed_body
+      expect(json['data'].size).to eq(1)
+      expect(json['meta']).to include('current_page' => 2, 'total_pages' => 2, 'per_page' => 2)
+    end
+
+    it 'filters by q[name_cont] (Ransack allowlist)' do
+      target = create(:greentea, name: '宇治抹茶パフェ専門店')
+
+      get '/api/v1/greenteas', params: { q: { name_cont: '宇治抹茶' } }
+
+      ids = response.parsed_body['data'].map { |d| d['id'] }
+      expect(ids).to eq([target.id])
+    end
+
+    it 'filters by q[genres_id_eq]' do
+      genre = create(:genre)
+      target = create(:greentea)
+      create(:greentea_genre, greentea: target, genre: genre)
+
+      get '/api/v1/greenteas', params: { q: { genres_id_eq: genre.id } }
+
+      ids = response.parsed_body['data'].map { |d| d['id'] }
+      expect(ids).to eq([target.id])
+    end
+
+    # Web 既存検索フォームの ransack キーが allowlist で通ることの回帰テスト
+    it 'accepts q[name_or_description_or_address_or_access_cont] (legacy web key)' do
+      target = create(:greentea, description: 'とろける宇治抹茶のティラミス')
+
+      get '/api/v1/greenteas', params: { q: { name_or_description_or_address_or_access_cont: 'とろける宇治抹茶' } }
+
+      ids = response.parsed_body['data'].map { |d| d['id'] }
+      expect(ids).to eq([target.id])
+    end
+
+    it 'accepts q[greentea_genres_genre_id_eq_any] (legacy web key)' do
+      genre = create(:genre)
+      target = create(:greentea)
+      create(:greentea_genre, greentea: target, genre: genre)
+
+      get '/api/v1/greenteas', params: { q: { greentea_genres_genre_id_eq_any: [genre.id] } }
+
+      ids = response.parsed_body['data'].map { |d| d['id'] }
+      expect(ids).to eq([target.id])
+    end
+
+    it 'returns like_count aggregated per record' do
+      liked = greenteas.first
+      user_a = create(:user)
+      user_b = create(:user)
+      GreenteaLike.create!(user: user_a, greentea: liked)
+      GreenteaLike.create!(user: user_b, greentea: liked)
+
+      get '/api/v1/greenteas'
+
+      payload = response.parsed_body['data'].find { |d| d['id'] == liked.id }
+      expect(payload['like_count']).to eq(2)
+    end
+  end
+
+  describe 'GET /api/v1/greenteas/:id' do
+    let(:greentea) { create(:greentea, latitude: 34.9676, longitude: 135.7741) }
+
+    it 'returns 200 with detail fields' do
+      get "/api/v1/greenteas/#{greentea.id}"
+
+      expect(response).to have_http_status(:ok)
+      attrs = response.parsed_body['data']
+      expect(attrs).to include(
+        'id', 'name', 'description', 'address', 'access', 'business_hours',
+        'holiday', 'phone_number', 'homepage', 'latitude', 'longitude', 'img',
+        'like_count', 'liked_by_current_user', 'genres', 'nearby_temples'
+      )
+      expect(attrs['id']).to eq(greentea.id)
+    end
+
+    it 'includes nearby_temples sorted by distance ascending with meter values' do
+      near = create(:temple, latitude: 34.96770, longitude: 135.77410)
+      mid  = create(:temple, latitude: 34.96900, longitude: 135.77410)
+
+      get "/api/v1/greenteas/#{greentea.id}"
+
+      nearby = response.parsed_body['data']['nearby_temples']
+      expect(nearby.map { |t| t['id'] }).to eq([near.id, mid.id])
+      nearby.each do |t|
+        expect(t).to include('id', 'name', 'latitude', 'longitude', 'distance_meters')
+        expect(t['distance_meters']).to be_a(Integer)
+      end
+
+      origin = Geokit::LatLng.new(greentea.latitude, greentea.longitude)
+      expected_near = (origin.distance_to(Geokit::LatLng.new(near.latitude, near.longitude)) * 1000).round
+      expected_mid  = (origin.distance_to(Geokit::LatLng.new(mid.latitude, mid.longitude)) * 1000).round
+      expect(nearby[0]['distance_meters']).to be_within(2).of(expected_near)
+      expect(nearby[1]['distance_meters']).to be_within(2).of(expected_mid)
+
+      distances = nearby.map { |t| t['distance_meters'] }
+      expect(distances).to eq(distances.sort)
+    end
+
+    it 'returns 404 with error body for missing id' do
+      get '/api/v1/greenteas/999999'
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq('error' => 'Not Found')
+    end
+  end
+end

--- a/spec/requests/api/v1/temples_spec.rb
+++ b/spec/requests/api/v1/temples_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Temples', type: :request do
+  describe 'GET /api/v1/temples' do
+    let!(:temples) { create_list(:temple, 3) }
+
+    it 'returns 200 with data and meta' do
+      get '/api/v1/temples'
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json['data'].size).to eq(3)
+      expect(json['meta']).to include(
+        'current_page' => 1,
+        'total_count' => 3,
+        'per_page' => 15
+      )
+    end
+
+    it 'returns flat snake_case spot fields' do
+      get '/api/v1/temples'
+
+      attrs = response.parsed_body['data'].first
+      expect(attrs).to include(
+        'id', 'name', 'address', 'access', 'business_hours', 'holiday',
+        'latitude', 'longitude', 'img', 'like_count', 'liked_by_current_user'
+      )
+    end
+
+    it 'filters by q[areas_id_eq]' do
+      area = create(:area)
+      target = create(:temple)
+      create(:temple_area, temple: target, area: area)
+
+      get '/api/v1/temples', params: { q: { areas_id_eq: area.id } }
+
+      ids = response.parsed_body['data'].map { |d| d['id'] }
+      expect(ids).to eq([target.id])
+    end
+
+    # Web 既存検索フォームの ransack キーが allowlist で通ることの回帰テスト
+    it 'accepts q[name_or_description_or_address_or_access_cont] (legacy web key)' do
+      target = create(:temple, description: '紅葉の名所として知られる古刹')
+
+      get '/api/v1/temples', params: { q: { name_or_description_or_address_or_access_cont: '紅葉の名所' } }
+
+      ids = response.parsed_body['data'].map { |d| d['id'] }
+      expect(ids).to eq([target.id])
+    end
+
+    it 'accepts q[temple_areas_area_id_eq_any] (legacy web key)' do
+      area = create(:area)
+      target = create(:temple)
+      create(:temple_area, temple: target, area: area)
+
+      get '/api/v1/temples', params: { q: { temple_areas_area_id_eq_any: [area.id] } }
+
+      ids = response.parsed_body['data'].map { |d| d['id'] }
+      expect(ids).to eq([target.id])
+    end
+  end
+
+  describe 'GET /api/v1/temples/:id' do
+    let(:temple) { create(:temple, latitude: 34.9676, longitude: 135.7741) }
+
+    it 'returns 200 with detail fields and nearby_greenteas in meters' do
+      near = create(:greentea, latitude: 34.96770, longitude: 135.77410)
+
+      get "/api/v1/temples/#{temple.id}"
+
+      expect(response).to have_http_status(:ok)
+      attrs = response.parsed_body['data']
+      expect(attrs).to include(
+        'id', 'name', 'description', 'address', 'access', 'business_hours',
+        'holiday', 'phone_number', 'homepage', 'latitude', 'longitude', 'img',
+        'like_count', 'liked_by_current_user', 'areas', 'nearby_greenteas'
+      )
+      expect(attrs['nearby_greenteas'].map { |g| g['id'] }).to include(near.id)
+      attrs['nearby_greenteas'].each do |g|
+        expect(g).to include('id', 'name', 'latitude', 'longitude', 'distance_meters')
+        expect(g['distance_meters']).to be_a(Integer)
+      end
+
+      origin = Geokit::LatLng.new(temple.latitude, temple.longitude)
+      expected = (origin.distance_to(Geokit::LatLng.new(near.latitude, near.longitude)) * 1000).round
+      near_payload = attrs['nearby_greenteas'].find { |g| g['id'] == near.id }
+      expect(near_payload['distance_meters']).to be_within(2).of(expected)
+    end
+
+    it 'returns 404 with error body for missing id' do
+      get '/api/v1/temples/999999'
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq('error' => 'Not Found')
+    end
+  end
+end


### PR DESCRIPTION
## 概要

#126 はレビュー反映前にマージしてしまい #127 でリバート済み。
本 PR では PR #126 に付いたレビュー指摘を反映した状態で再実装する。

Closes #114

## 追加エンドポイント

| Method | Path | 用途 |
|---|---|---|
| GET | `/api/v1/greenteas` | 抹茶店一覧（Ransack + Kaminari） |
| GET | `/api/v1/greenteas/:id` | 詳細 + `nearby_temples`（1.5km 圏内、距離昇順） |
| GET | `/api/v1/temples` | 神社仏閣一覧 |
| GET | `/api/v1/temples/:id` | 詳細 + `nearby_greenteas` |
| GET | `/api/v1/genres` | ジャンル一覧 |
| GET | `/api/v1/areas` | エリア一覧 |

## #126 のレビュー指摘を反映した差分

### 機能・正しさ系（Major）

- **CodeRabbit「`render_simple_collection` に meta が無い」(areas_controller.rb)**
  CLAUDE.md の規約「一覧の meta は `{ current_page, total_pages, total_count, per_page }` で統一」に合わせ、Areas / Genres も `paginate` + `render_collection` で `meta` を返すように変更。`render_simple_collection` ヘルパーは廃止して `render_collection` に一本化。
- **CodeRabbit「`ransackable_associations` を allowlist で明示」(area.rb / genre.rb)**
  両モデルに `def self.ransackable_associations(_auth_object = nil) = []` を追加。
- **CodeRabbit「nearby の origin ガード」(greentea_detail_serializer.rb 11-13)**
  `[obj.latitude, obj.longitude]` を無条件で渡すと、`NearbyTempleSerializer` 側の `if origin` チェックが配列の truthy 評価で常に通り、座標が nil でも `get_distance` が呼ばれてしまう不具合。Detail serializer 側で「両座標が non-nil の場合のみ origin を渡す」ように修正し、Nearby serializer 側でも `origin && origin[0] && origin[1]` を追加でガード。
- **CodeRabbit「`distance_meters` が `by_distance` のソート順とずれる可能性」(greentea_detail_serializer.rb 23-28)**
  Geokit `by_distance` は SQL で計算した `distance` カラムでソートする。一方 PR #126 では serializer 内で `obj.get_distance(...)` を再計算（`.round(-1)` で 10m 単位に丸め）していたため、表示値と SQL ソート順が乖離するケースがあった。Nearby serializer を「`obj.distance`（Geokit が SELECT で付与した km）を最優先で `* 1000` してから `.round` で整数化」する実装に変更。これにより `distance_meters` は常に SQL の by_distance 順と一致する。
- **CodeRabbit「404 のレスポンスボディも assert」(temples_spec.rb 64-68)**
  Greenteas 側に合わせて `{ 'error' => 'Not Found' }` を assert。

### Nitpick 系

- **Gemfile**: `gem 'jsonapi-serializer', '~> 2.2'` でバージョンをピン留め。
- **各 serializer**: デフォルトと同義の `set_id { |obj| obj.id }` を削除（RuboCop `Style/SymbolProc` 回避兼ねる）。
- **areas_spec / genres_spec**: id 昇順で並んでいることを assert。
- **greenteas_spec / temples_spec**: `nearby_*` の `distance_meters` の実値も `Geokit::LatLng#distance_to(... ) * 1000` ベースで近似 assert（メートル単位であることを担保）。

### Codex 指摘の継承（#126 の f84edd8 で対応済みの内容）

- 既存 Web 検索フォームが送る `q[name_or_description_or_address_or_access_cont]` と `q[greentea_genres_genre_id_eq_any]` / `q[temple_areas_area_id_eq_any]` が allowlist 漏れで動かなくなる問題を防ぐため、`Greentea` / `Temple` に `description` 属性、`greentea_genres` / `temple_areas` 関連を追加。レガシーキーの回帰テストも追加。

## レスポンス共通仕様（変更なし）

- snake_case のフラット形式（フロント mock と同スキーマ）
- 一覧の `meta`: `{ current_page, total_pages, total_count, per_page }`（Areas / Genres にも適用）
- `per_page` は 1〜100 にクランプ
- 詳細の `nearby_*`: `{ id, name, latitude, longitude, distance_meters }`
- `liked_by_current_user` は #116 (JWT) 着地まで `false` 固定

## テスト

`spec/requests/api/v1/` の request spec を更新:

- [x] 一覧 / 詳細の正常系（フィールド整合）
- [x] Ransack 検索（`name_cont` / `genres_id_eq` / `areas_id_eq`）
- [x] レガシー Web 検索キーの回帰テスト
- [x] ページネーション（`per_page` / `page` / `meta`）
- [x] `like_count` 集計
- [x] `nearby_*` の距離昇順 + 実 meter 値の妥当性
- [x] 404 (`/greenteas/999999` / `/temples/999999`) のボディも assert
- [x] Areas / Genres の id 昇順 + meta 付与

> **ローカル検証について**: 本コンテナに Ruby 3.3.11 / bundler 環境が無く `bundle install` / `rspec` をローカル実行できなかったため、構文チェック (`ruby -c`) のみ実施。CI または手元の 3.3.11 環境で `bundle exec rspec spec/requests/api/v1/` を実行してください。

## 残タスク（このPRのスコープ外）

- `liked_by_current_user` の実値化 → **#116**
- いいね・コメント API → **#116**
- 近隣検索 API (`/api/v1/nearby`) → **#117**


---
_Generated by [Claude Code](https://claude.ai/code/session_01673j7pzjEDdMyMBQeUfFXe)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added REST API endpoints for areas, genres, greenteas, and temples with list and detail views
  * Implemented search and filtering capabilities across greenteas and temples
  * Added pagination support to all collection endpoints
  * Introduced like counts for greenteas and temples
  * Added nearby locations feature: nearby temples visible from greentea details; nearby greenteas visible from temple details
  * Distance calculations displayed in meters for nearby locations

* **Tests**
  * Added comprehensive request specs for all new API endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->