### PR TITLE
feat: JWT 認証 API を実装 (#115)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,9 @@ gem 'rack-cors'
 # JSON serializer for API (#114)
 gem 'jsonapi-serializer', '~> 2.2'
 
+# JWT for API authentication (#115)
+gem 'jwt', '~> 3.2'
+
 # Localization
 gem 'rails-i18n'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -527,6 +527,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   jsonapi-serializer (~> 2.2)
+  jwt (~> 3.2)
   kaminari
   meta-tags
   mini_magick

--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -31,18 +31,16 @@ module Api
       end
 
       def upsert_user_from(user_info)
+        existing = Authentication.find_by(provider: user_info[:provider], uid: user_info[:uid])
+        return existing.user if existing
+
         ActiveRecord::Base.transaction do
-          auth = Authentication.find_or_initialize_by(
-            provider: user_info[:provider],
-            uid: user_info[:uid]
-          )
-          if auth.new_record?
-            user = User.create!(name: user_info[:name].presence || 'ユーザー')
-            auth.user = user
-            auth.save!
-          end
-          auth.user
+          user = User.create!(name: user_info[:name].presence || 'ユーザー')
+          Authentication.create!(user: user, provider: user_info[:provider], uid: user_info[:uid])
+          user
         end
+      rescue ActiveRecord::RecordNotUnique
+        Authentication.find_by!(provider: user_info[:provider], uid: user_info[:uid]).user
       end
     end
   end

--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -1,0 +1,49 @@
+module Api
+  module V1
+    class AuthController < BaseController
+      def create
+        provider = params[:provider]
+        unless OauthUserInfoFetcher::SUPPORTED_PROVIDERS.include?(provider)
+          return render json: { error: 'Unsupported provider' }, status: :bad_request
+        end
+
+        user_info = OauthUserInfoFetcher.fetch(provider, auth_params.to_h.symbolize_keys)
+        user = upsert_user_from(user_info)
+        token = JwtService.encode(user_id: user.id, provider: provider)
+
+        render json: {
+          jwt: token,
+          user: serialize_user_payload(user)
+        }
+      rescue OauthUserInfoFetcher::FetchError => e
+        Rails.logger.info("OAuth token verification failed: #{e.message}")
+        render json: { error: 'Unauthorized' }, status: :unauthorized
+      end
+
+      def destroy
+        head :no_content
+      end
+
+      private
+
+      def auth_params
+        params.permit(:access_token, :access_token_secret)
+      end
+
+      def upsert_user_from(user_info)
+        ActiveRecord::Base.transaction do
+          auth = Authentication.find_or_initialize_by(
+            provider: user_info[:provider],
+            uid: user_info[:uid]
+          )
+          if auth.new_record?
+            user = User.create!(name: user_info[:name].presence || 'ユーザー')
+            auth.user = user
+            auth.save!
+          end
+          auth.user
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -14,7 +14,43 @@ module Api
         render json: { error: 'Not Found' }, status: :not_found
       end
 
+      def current_user
+        return @current_user if defined?(@current_user)
+
+        @current_user = authenticate_with_token
+      end
+
+      def require_authentication!
+        return if current_user
+
+        render json: { error: 'Unauthorized' }, status: :unauthorized
+      end
+
       private
+
+      def authenticate_with_token
+        token = bearer_token
+        return nil if token.blank?
+
+        payload = JwtService.decode(token)
+        User.find_by(id: payload['user_id'])
+      rescue JwtService::Error => e
+        Rails.logger.info("JWT auth failed: #{e.class} #{e.message}")
+        nil
+      end
+
+      def bearer_token
+        header = request.headers['Authorization']
+        return nil unless header.is_a?(String)
+        return nil unless header.start_with?('Bearer ')
+
+        header.split(' ', 2).last
+      end
+
+      def serialize_user_payload(user)
+        serialized = UserSerializer.new(user).serializable_hash
+        flatten_one(serialized[:data])
+      end
 
       def paginate(scope)
         per_page = params[:per_page].to_i

--- a/app/controllers/api/v1/current_user_controller.rb
+++ b/app/controllers/api/v1/current_user_controller.rb
@@ -1,0 +1,11 @@
+module Api
+  module V1
+    class CurrentUserController < BaseController
+      before_action :require_authentication!
+
+      def show
+        render json: { data: serialize_user_payload(current_user) }
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,0 +1,9 @@
+module Api
+  module V1
+    class UserSerializer
+      include JSONAPI::Serializer
+
+      attributes :name, :role
+    end
+  end
+end

--- a/app/services/jwt_service.rb
+++ b/app/services/jwt_service.rb
@@ -25,12 +25,14 @@ class JwtService
     private
 
     def secret_key
-      credentials_key = Rails.application.credentials.dig(:jwt_secret).presence
+      credentials_key = Rails.application.credentials[:jwt_secret].presence
       env_key = ENV['JWT_SECRET_KEY'].presence
       return credentials_key || env_key if credentials_key || env_key
 
-      raise MissingSecretError,
-            'JWT secret is not configured. Set credentials :jwt_secret or ENV["JWT_SECRET_KEY"].' unless Rails.env.test?
+      unless Rails.env.test?
+        raise MissingSecretError,
+              'JWT secret is not configured. Set credentials :jwt_secret or ENV["JWT_SECRET_KEY"].'
+      end
 
       'test_jwt_secret_do_not_use_in_production'
     end

--- a/app/services/jwt_service.rb
+++ b/app/services/jwt_service.rb
@@ -1,0 +1,38 @@
+class JwtService
+  ALGORITHM = 'HS256'.freeze
+  EXPIRES_IN = 14.days
+
+  class Error < StandardError; end
+  class InvalidTokenError < Error; end
+  class ExpiredTokenError < Error; end
+  class MissingSecretError < Error; end
+
+  class << self
+    def encode(payload, expires_at: EXPIRES_IN.from_now)
+      claims = payload.merge(exp: expires_at.to_i)
+      ::JWT.encode(claims, secret_key, ALGORITHM)
+    end
+
+    def decode(token)
+      payload, _header = ::JWT.decode(token, secret_key, true, algorithm: ALGORITHM)
+      payload
+    rescue ::JWT::ExpiredSignature => e
+      raise ExpiredTokenError, e.message
+    rescue ::JWT::DecodeError => e
+      raise InvalidTokenError, e.message
+    end
+
+    private
+
+    def secret_key
+      credentials_key = Rails.application.credentials.dig(:jwt_secret).presence
+      env_key = ENV['JWT_SECRET_KEY'].presence
+      return credentials_key || env_key if credentials_key || env_key
+
+      raise MissingSecretError,
+            'JWT secret is not configured. Set credentials :jwt_secret or ENV["JWT_SECRET_KEY"].' unless Rails.env.test?
+
+      'test_jwt_secret_do_not_use_in_production'
+    end
+  end
+end

--- a/app/services/oauth_user_info_fetcher.rb
+++ b/app/services/oauth_user_info_fetcher.rb
@@ -1,0 +1,20 @@
+module OauthUserInfoFetcher
+  class FetchError < StandardError; end
+  class UnsupportedProviderError < StandardError; end
+
+  SUPPORTED_PROVIDERS = %w[twitter line].freeze
+
+  def self.fetch(provider, params)
+    case provider.to_s
+    when 'twitter'
+      Twitter.new(
+        access_token: params[:access_token],
+        access_token_secret: params[:access_token_secret]
+      ).call
+    when 'line'
+      Line.new(access_token: params[:access_token]).call
+    else
+      raise UnsupportedProviderError, "Unsupported provider: #{provider}"
+    end
+  end
+end

--- a/app/services/oauth_user_info_fetcher/line.rb
+++ b/app/services/oauth_user_info_fetcher/line.rb
@@ -1,9 +1,12 @@
 require 'net/http'
+require 'openssl'
 require 'json'
 
 module OauthUserInfoFetcher
   class Line
     PROFILE_URL = URI('https://api.line.me/v2/profile').freeze
+    OPEN_TIMEOUT = 5
+    READ_TIMEOUT = 5
 
     def initialize(access_token:)
       @access_token = access_token
@@ -23,6 +26,8 @@ module OauthUserInfoFetcher
       }
     rescue ::JSON::ParserError => e
       raise FetchError, "Invalid LINE response: #{e.message}"
+    rescue ::Net::OpenTimeout, ::Net::ReadTimeout, ::SocketError, ::OpenSSL::SSL::SSLError => e
+      raise FetchError, "LINE request failed: #{e.message}"
     end
 
     private
@@ -30,7 +35,8 @@ module OauthUserInfoFetcher
     def fetch_profile
       request = Net::HTTP::Get.new(PROFILE_URL)
       request['Authorization'] = "Bearer #{@access_token}"
-      Net::HTTP.start(PROFILE_URL.hostname, PROFILE_URL.port, use_ssl: true) do |http|
+      Net::HTTP.start(PROFILE_URL.hostname, PROFILE_URL.port,
+                      use_ssl: true, open_timeout: OPEN_TIMEOUT, read_timeout: READ_TIMEOUT) do |http|
         http.request(request)
       end
     end

--- a/app/services/oauth_user_info_fetcher/line.rb
+++ b/app/services/oauth_user_info_fetcher/line.rb
@@ -1,0 +1,38 @@
+require 'net/http'
+require 'json'
+
+module OauthUserInfoFetcher
+  class Line
+    PROFILE_URL = URI('https://api.line.me/v2/profile').freeze
+
+    def initialize(access_token:)
+      @access_token = access_token
+    end
+
+    def call
+      raise FetchError, 'access_token is required' if @access_token.blank?
+
+      response = fetch_profile
+      raise FetchError, "LINE API error: #{response.code}" unless response.code.to_i == 200
+
+      payload = JSON.parse(response.body)
+      {
+        provider: 'line',
+        uid: payload['userId'].to_s,
+        name: payload['displayName']
+      }
+    rescue ::JSON::ParserError => e
+      raise FetchError, "Invalid LINE response: #{e.message}"
+    end
+
+    private
+
+    def fetch_profile
+      request = Net::HTTP::Get.new(PROFILE_URL)
+      request['Authorization'] = "Bearer #{@access_token}"
+      Net::HTTP.start(PROFILE_URL.hostname, PROFILE_URL.port, use_ssl: true) do |http|
+        http.request(request)
+      end
+    end
+  end
+end

--- a/app/services/oauth_user_info_fetcher/twitter.rb
+++ b/app/services/oauth_user_info_fetcher/twitter.rb
@@ -1,0 +1,45 @@
+require 'oauth'
+require 'json'
+
+module OauthUserInfoFetcher
+  class Twitter
+    SITE = 'https://api.twitter.com'.freeze
+    VERIFY_PATH = '/1.1/account/verify_credentials.json?include_email=true'.freeze
+
+    def initialize(access_token:, access_token_secret:)
+      @access_token = access_token
+      @access_token_secret = access_token_secret
+    end
+
+    def call
+      raise FetchError, 'access_token is required' if @access_token.blank?
+      raise FetchError, 'access_token_secret is required' if @access_token_secret.blank?
+
+      response = fetch_user_info
+      raise FetchError, "Twitter API error: #{response.code}" unless response.code.to_i == 200
+
+      payload = JSON.parse(response.body)
+      {
+        provider: 'twitter',
+        uid: payload['id_str'].to_s,
+        name: payload['name'].presence || payload['screen_name']
+      }
+    rescue ::OAuth::Unauthorized => e
+      raise FetchError, "Twitter unauthorized: #{e.message}"
+    rescue ::JSON::ParserError => e
+      raise FetchError, "Invalid Twitter response: #{e.message}"
+    end
+
+    private
+
+    def fetch_user_info
+      consumer = ::OAuth::Consumer.new(
+        Rails.application.credentials.dig(:twitter, :key),
+        Rails.application.credentials.dig(:twitter, :secret_key),
+        site: SITE
+      )
+      token = ::OAuth::AccessToken.new(consumer, @access_token, @access_token_secret)
+      token.get(VERIFY_PATH)
+    end
+  end
+end

--- a/app/services/oauth_user_info_fetcher/twitter.rb
+++ b/app/services/oauth_user_info_fetcher/twitter.rb
@@ -1,10 +1,12 @@
 require 'oauth'
+require 'openssl'
 require 'json'
 
 module OauthUserInfoFetcher
   class Twitter
     SITE = 'https://api.twitter.com'.freeze
     VERIFY_PATH = '/1.1/account/verify_credentials.json?include_email=true'.freeze
+    TIMEOUT = 5
 
     def initialize(access_token:, access_token_secret:)
       @access_token = access_token
@@ -28,6 +30,10 @@ module OauthUserInfoFetcher
       raise FetchError, "Twitter unauthorized: #{e.message}"
     rescue ::JSON::ParserError => e
       raise FetchError, "Invalid Twitter response: #{e.message}"
+    rescue ::Net::OpenTimeout, ::Net::ReadTimeout, ::SocketError, ::OpenSSL::SSL::SSLError => e
+      raise FetchError, "Twitter request failed: #{e.message}"
+    rescue ::OAuth::Error => e
+      raise FetchError, "Twitter OAuth error: #{e.message}"
     end
 
     private
@@ -36,7 +42,8 @@ module OauthUserInfoFetcher
       consumer = ::OAuth::Consumer.new(
         Rails.application.credentials.dig(:twitter, :key),
         Rails.application.credentials.dig(:twitter, :secret_key),
-        site: SITE
+        site: SITE,
+        timeout: TIMEOUT
       )
       token = ::OAuth::AccessToken.new(consumer, @access_token, @access_token_secret)
       token.get(VERIFY_PATH)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,10 @@ Rails.application.routes.draw do
     namespace :v1 do
       get 'health', to: 'health#show'
 
+      delete 'auth/logout', to: 'auth#destroy'
+      post 'auth/:provider', to: 'auth#create', constraints: { provider: /twitter|line/ }
+      get 'current_user', to: 'current_user#show'
+
       resources :greenteas, only: %i[index show]
       resources :temples, only: %i[index show]
       resources :genres, only: %i[index]

--- a/db/migrate/20260603040345_add_unique_index_to_authentications_provider_uid.rb
+++ b/db/migrate/20260603040345_add_unique_index_to_authentications_provider_uid.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToAuthenticationsProviderUid < ActiveRecord::Migration[7.1]
+  def change
+    remove_index :authentications, name: 'index_authentications_on_provider_and_uid'
+    add_index :authentications, %i[provider uid], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_11_062514) do
+ActiveRecord::Schema[7.0].define(version: 2026_06_03_040345) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,7 +40,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_11_062514) do
     t.string "uid", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
+    t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid", unique: true
   end
 
   create_table "genres", force: :cascade do |t|

--- a/spec/requests/api/v1/auth_spec.rb
+++ b/spec/requests/api/v1/auth_spec.rb
@@ -53,6 +53,24 @@ RSpec.describe 'Api::V1::Auth', type: :request do
         expect(decoded['provider']).to eq('line')
         expect(decoded['exp']).to be_within(60).of(14.days.from_now.to_i)
       end
+
+      it 'recovers from RecordNotUnique race by re-finding the Authentication' do
+        existing_user = User.create!(name: '別タブで先にログイン')
+        Authentication.create!(user: existing_user, provider: 'line', uid: 'U1234567890abcdef')
+
+        # 一度 find_by を nil に倒し、create! で RecordNotUnique を発生させる
+        allow(Authentication).to receive(:find_by).and_call_original
+        allow(Authentication).to receive(:find_by)
+          .with(provider: 'line', uid: 'U1234567890abcdef')
+          .and_return(nil, existing_user.authentications.first)
+
+        expect {
+          post '/api/v1/auth/line', params: { access_token: 'valid_line_token' }
+        }.not_to change(Authentication, :count)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['user']['id']).to eq(existing_user.id)
+      end
     end
 
     context 'with valid Twitter access_token + secret' do

--- a/spec/requests/api/v1/auth_spec.rb
+++ b/spec/requests/api/v1/auth_spec.rb
@@ -1,0 +1,104 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Auth', type: :request do
+  describe 'POST /api/v1/auth/:provider' do
+    let(:line_user_info) do
+      { provider: 'line', uid: 'U1234567890abcdef', name: 'もちもち抹茶' }
+    end
+
+    context 'with valid LINE access_token' do
+      before do
+        allow(OauthUserInfoFetcher).to receive(:fetch)
+          .with('line', hash_including(access_token: 'valid_line_token'))
+          .and_return(line_user_info)
+      end
+
+      it 'creates a new User + Authentication and returns jwt + user' do
+        expect {
+          post '/api/v1/auth/line', params: { access_token: 'valid_line_token' }
+        }.to change(User, :count).by(1).and change(Authentication, :count).by(1)
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body['jwt']).to be_a(String).and be_present
+        expect(body['user']).to include('id', 'name', 'role')
+        expect(body['user']['name']).to eq('もちもち抹茶')
+
+        auth = Authentication.last
+        expect(auth.provider).to eq('line')
+        expect(auth.uid).to eq('U1234567890abcdef')
+        expect(auth.user.name).to eq('もちもち抹茶')
+      end
+
+      it 'returns the existing User when the same (provider, uid) is already linked' do
+        existing_user = User.create!(name: '既存ユーザー')
+        Authentication.create!(user: existing_user, provider: 'line', uid: 'U1234567890abcdef')
+
+        expect {
+          post '/api/v1/auth/line', params: { access_token: 'valid_line_token' }
+        }.not_to change(User, :count)
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body['user']['id']).to eq(existing_user.id)
+        decoded = JwtService.decode(body['jwt'])
+        expect(decoded['user_id']).to eq(existing_user.id)
+      end
+
+      it 'embeds user_id and provider in the JWT and sets exp ~14 days ahead' do
+        post '/api/v1/auth/line', params: { access_token: 'valid_line_token' }
+
+        decoded = JwtService.decode(response.parsed_body['jwt'])
+        expect(decoded['user_id']).to eq(User.last.id)
+        expect(decoded['provider']).to eq('line')
+        expect(decoded['exp']).to be_within(60).of(14.days.from_now.to_i)
+      end
+    end
+
+    context 'with valid Twitter access_token + secret' do
+      before do
+        allow(OauthUserInfoFetcher).to receive(:fetch)
+          .with('twitter', hash_including(access_token: 'tw_token', access_token_secret: 'tw_secret'))
+          .and_return(provider: 'twitter', uid: '1234567890', name: 'matcha_san')
+      end
+
+      it 'creates the User via Twitter provider' do
+        post '/api/v1/auth/twitter',
+             params: { access_token: 'tw_token', access_token_secret: 'tw_secret' }
+
+        expect(response).to have_http_status(:ok)
+        expect(Authentication.last).to have_attributes(provider: 'twitter', uid: '1234567890')
+      end
+    end
+
+    context 'when provider verification fails' do
+      before do
+        allow(OauthUserInfoFetcher).to receive(:fetch)
+          .and_raise(OauthUserInfoFetcher::FetchError, 'invalid token')
+      end
+
+      it 'returns 401 without creating a User' do
+        expect {
+          post '/api/v1/auth/line', params: { access_token: 'bogus' }
+        }.not_to change(User, :count)
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body).to eq('error' => 'Unauthorized')
+      end
+    end
+
+    context 'with unsupported provider' do
+      it 'returns 404 (route constraint blocks the path)' do
+        post '/api/v1/auth/facebook', params: { access_token: 'x' }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe 'DELETE /api/v1/auth/logout' do
+    it 'returns 204 (stateless logout)' do
+      delete '/api/v1/auth/logout'
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+end

--- a/spec/requests/api/v1/current_user_spec.rb
+++ b/spec/requests/api/v1/current_user_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::CurrentUser', type: :request do
+  describe 'GET /api/v1/current_user' do
+    let(:user) { User.create!(name: '抹茶ファン1号') }
+
+    def auth_header(token)
+      { 'Authorization' => "Bearer #{token}" }
+    end
+
+    context 'with a valid JWT' do
+      it 'returns 200 with the user payload' do
+        token = JwtService.encode(user_id: user.id)
+
+        get '/api/v1/current_user', headers: auth_header(token)
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body['data']).to include(
+          'id' => user.id,
+          'name' => '抹茶ファン1号'
+        )
+        expect(body['data']).to have_key('role')
+      end
+    end
+
+    context 'without a token' do
+      it 'returns 401' do
+        get '/api/v1/current_user'
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body).to eq('error' => 'Unauthorized')
+      end
+    end
+
+    context 'with a malformed Authorization header' do
+      it 'returns 401' do
+        get '/api/v1/current_user', headers: { 'Authorization' => 'token-without-bearer' }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'with an invalid signature' do
+      it 'returns 401' do
+        bogus = JWT.encode({ user_id: user.id, exp: 1.hour.from_now.to_i }, 'wrong_secret', 'HS256')
+        get '/api/v1/current_user', headers: auth_header(bogus)
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'with an expired JWT' do
+      it 'returns 401' do
+        token = JwtService.encode({ user_id: user.id }, expires_at: 1.minute.ago)
+        get '/api/v1/current_user', headers: auth_header(token)
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when the user no longer exists' do
+      it 'returns 401' do
+        token = JwtService.encode(user_id: user.id)
+        user.destroy!
+
+        get '/api/v1/current_user', headers: auth_header(token)
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Next.js フロント（NextAuth.js）向けに JWT 発行 / 検証 API を実装した。
既存の Sorcery + OAuth（Twitter / LINE）資産を活かしつつ、フロントには **Rails 発行の JWT** を返す形に揃える。

Closes #115

## エンドポイント

| Method | Path | 認証 | 概要 |
|---|---|---|---|
| POST | `/api/v1/auth/:provider` | 不要 | provider = `twitter` / `line`。`access_token`（+ Twitter は `access_token_secret`）を検証 → User upsert → `{ jwt, user }` 返却 |
| DELETE | `/api/v1/auth/logout` | 不要 | ステートレス。`204 No Content` を返すだけ |
| GET | `/api/v1/current_user` | **必須** | JWT から User を解決して `{ data: { id, name, role } }` を返す |

## 変更点

### 追加

- `app/services/jwt_service.rb`
  - HS256 / 有効期限 14 日（`JwtService::EXPIRES_IN`）
  - 鍵: `Rails.application.credentials.dig(:jwt_secret)` → `ENV['JWT_SECRET_KEY']` の順
  - 鍵未設定で `MissingSecretError`、test 環境のみ固定フォールバック鍵を許容
  - 期限切れ / 改ざんを `ExpiredTokenError` / `InvalidTokenError` で区別
- `app/services/oauth_user_info_fetcher.rb`（+ `twitter.rb` / `line.rb`）
  - フロントから渡された `access_token` を **実プロバイダで再検証**してから User を解決（フロントの主張を信用しない）
  - Twitter: OAuth 1.0a の `verify_credentials.json`（`oauth` gem を使用、`access_token` + `access_token_secret` 必須）
  - LINE: OAuth 2.0 の `v2/profile`（Bearer token）
  - 共通エラーは `OauthUserInfoFetcher::FetchError`
- `app/controllers/api/v1/auth_controller.rb`
  - `create`: provider allowlist → `OauthUserInfoFetcher.fetch` → `Authentication.find_or_initialize_by(provider, uid)` で upsert → JWT 発行
  - `destroy`: ステートレスログアウト（クライアントが破棄）
- `app/controllers/api/v1/current_user_controller.rb`
  - `before_action :require_authentication!` で 401 を保証
- `app/serializers/api/v1/user_serializer.rb`（`name`, `role`）
- request spec: `spec/requests/api/v1/auth_spec.rb` / `current_user_spec.rb`

### 変更

- `app/controllers/api/v1/base_controller.rb`
  - `current_user`（memo 化、未認証は `nil`）
  - `require_authentication!`（401 で打ち切り）
  - `authenticate_with_token` / `bearer_token`（`Authorization: Bearer` から JWT 抽出）
  - `serialize_user_payload`（auth / current_user 双方で再利用）
  - `JwtService::Error` を rescue して 401 に倒す（Web 側には影響なし）
- `config/routes.rb`
  - `delete 'auth/logout'`
  - `post 'auth/:provider', constraints: { provider: /twitter|line/ }`
  - `get 'current_user', to: 'current_user#show'`
  - 並び順: `logout` を先に書きつつ、`:provider` 側は constraint で `logout` を弾く
- `Gemfile` / `Gemfile.lock`: `gem 'jwt', '~> 3.2'` を明示追加（既存 sorcery 経由の transitive を昇格）

## レスポンス契約

```jsonc
// POST /api/v1/auth/line
// req: { access_token: "..." }
{
  "jwt": "eyJhbGciOi...",
  "user": { "id": 42, "name": "...", "role": "general" }
}

// GET /api/v1/current_user  (Authorization: Bearer <jwt>)
{
  "data": { "id": 42, "name": "...", "role": "general" }
}
```

- フロント (`matcha-to-jinja`) の `src/lib/auth.ts` の `jwt` callback の TODO を、`POST /api/v1/auth/:provider` 呼び出しに差し替えるだけで結合可能

## エラーレスポンス

| 状況 | ステータス | ボディ |
|---|---|---|
| `:provider` が allowlist 外（route constraints で弾く） | 404 | `{ error: "Not Found" }` |
| OAuth トークン検証失敗 | 401 | `{ error: "Unauthorized" }` |
| JWT なし / 不正 / 期限切れ / 該当 User なし | 401 | `{ error: "Unauthorized" }` |

## 設計判断（issue で「決定」を求められていた項目）

- **リフレッシュ戦略**: 一旦 **単一長命（14 日 access）** で着地。
  - 短命 access + リフレッシュトークンへの拡張は別 issue 化を提案。
  - 理由: 結合する Next.js 側（NextAuth）の session 寿命と二重管理になりがちで、まず最小構成でフロント結合を回したい。
- **OAuth 検証は Rails 側で必ず再実行**: フロントから来た `access_token` を信用せず、プロバイダ API で uid / name を取り直してから User を upsert。フロント改ざんによる成りすましを防ぐ。
- **`Authentication` の upsert キー**: `(provider, uid)` の組で `find_or_initialize_by`。既存 OAuth 経路と同じユーザー解決ロジックなので、Web ログインで作った User がそのまま JWT ログインで再利用される。

## 検証

- ローカル: Ruby 3.3.11 がサンドボックスの network policy で取得できず、3.3.6 でも `pg` / `stringio` の native extension コンパイルが通らないため、RSpec のローカル実行は不可。
  - 代わりに **全ファイルの Ruby シンタックスチェックは pass**
  - CI（GitHub Actions）での実行結果を確認する想定
- request spec で以下をカバー
  - 新規ユーザー作成 / 既存ユーザー解決 / JWT 中身（`user_id`, `provider`, `exp`）
  - OAuth 検証失敗 → 401
  - 未対応 provider → 404（route constraints）
  - 期限切れ JWT / 不正署名 / Bearer 無し / User 削除済 → 401

## Test plan

- [ ] CI 上で `bundle exec rspec spec/requests/api/v1/auth_spec.rb` が green
- [ ] CI 上で `bundle exec rspec spec/requests/api/v1/current_user_spec.rb` が green
- [ ] 既存の `spec/requests/api/v1/{health,greenteas,temples,areas,genres,route_not_found}_spec.rb` が引き続き green（base_controller 変更による回帰がないこと）
- [ ] 既存 Web 画面（ログイン / Administrate）に影響なし（API 経路のみの追加）

## 関連

- 親 issue: #113（API 基盤）✅ / #114（読み取り系 API）✅
- 次の依存先: #116（いいね・コメント API）は本 PR の `require_authentication!` を流用

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHm85anDCS3LTAKguMxtqL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth-based login with support for multiple providers
  * JWT authentication for API endpoints with bearer token validation
  * New endpoint to retrieve current authenticated user profile
  * User logout functionality

* **Tests**
  * Added tests for OAuth authentication flows
  * Added tests for API authentication including token validation scenarios

* **Dependencies**
  * Added JWT gem for authentication token handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->