### PR TITLE
feat: 近隣検索 API を実装 (#117)

### DIFF
--- a/app/controllers/api/v1/nearby_controller.rb
+++ b/app/controllers/api/v1/nearby_controller.rb
@@ -1,0 +1,58 @@
+module Api
+  module V1
+    class NearbyController < BaseController
+      DEFAULT_RADIUS_KM = 1.5
+      MAX_RADIUS_KM = 10
+      MAX_RESULTS = 50
+
+      def search
+        lat = parse_float(params[:lat])
+        lng = parse_float(params[:lng])
+        radius = params[:radius].present? ? parse_float(params[:radius]) : DEFAULT_RADIUS_KM
+
+        return render_bad_request unless valid_coordinates?(lat, lng) && valid_radius?(radius)
+
+        origin = [lat, lng]
+
+        render json: {
+          greenteas: nearby_records(Greentea, origin, radius, NearbyGreenteaSerializer),
+          temples: nearby_records(Temple, origin, radius, NearbyTempleSerializer)
+        }
+      end
+
+      private
+
+      def nearby_records(model, origin, radius, serializer)
+        records = model
+                  .within(radius, origin: origin)
+                  .by_distance(origin: origin)
+                  .limit(MAX_RESULTS)
+                  .load
+        serialized = serializer.new(records, params: { origin: origin }).serializable_hash
+        flatten_serialized(serialized[:data])
+      end
+
+      def parse_float(value)
+        return nil if value.blank?
+
+        Float(value)
+      rescue ArgumentError, TypeError
+        nil
+      end
+
+      def valid_coordinates?(lat, lng)
+        return false unless lat.is_a?(Numeric) && lng.is_a?(Numeric)
+        return false unless lat.finite? && lng.finite?
+
+        lat.abs <= 90 && lng.abs <= 180
+      end
+
+      def valid_radius?(radius)
+        return false unless radius.is_a?(Numeric)
+        return false unless radius.finite?
+
+        radius.positive? && radius <= MAX_RADIUS_KM
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
       resources :genres, only: %i[index]
       resources :areas, only: %i[index]
 
+      get 'nearby', to: 'nearby#search'
+
       resources :greentea_likes, only: %i[index create destroy]
       resources :temple_likes, only: %i[index create destroy]
       resources :greenteacomments, only: %i[index create destroy]

--- a/spec/requests/api/v1/nearby_spec.rb
+++ b/spec/requests/api/v1/nearby_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'Api::V1::Nearby', type: :request do
         get '/api/v1/nearby', params: { lat: origin_lat, lng: origin_lng }
 
         origin = Geokit::LatLng.new(origin_lat, origin_lng)
-        expected = (origin.distance_to(Geokit::LatLng.new(near_greentea.latitude, near_greentea.longitude)) * 1000).round
+        expected = (origin.distance_to(Geokit::LatLng.new(near_greentea.latitude, near_greentea.longitude), units: :kms) * 1000).round
         actual = response.parsed_body['greenteas'].find { |g| g['id'] == near_greentea.id }['distance_meters']
         expect(actual).to be_within(5).of(expected)
       end

--- a/spec/requests/api/v1/nearby_spec.rb
+++ b/spec/requests/api/v1/nearby_spec.rb
@@ -1,0 +1,166 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Nearby', type: :request do
+  describe 'GET /api/v1/nearby' do
+    # 京都駅近傍を原点に検証する
+    let(:origin_lat) { 34.9676 }
+    let(:origin_lng) { 135.7741 }
+
+    context 'with valid lat / lng' do
+      let!(:near_greentea) { create(:greentea, latitude: 34.96770, longitude: 135.77410) }
+      let!(:near_temple) { create(:temple, latitude: 34.96780, longitude: 135.77420) }
+      let!(:far_greentea) { create(:greentea, latitude: 35.10000, longitude: 135.90000) }
+      let!(:far_temple) { create(:temple, latitude: 35.10000, longitude: 135.90000) }
+
+      it 'returns 200 with greenteas and temples arrays' do
+        get '/api/v1/nearby', params: { lat: origin_lat, lng: origin_lng }
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json).to include('greenteas', 'temples')
+      end
+
+      it 'includes nearby spots within default 1.5km radius and excludes far ones' do
+        get '/api/v1/nearby', params: { lat: origin_lat, lng: origin_lng }
+
+        json = response.parsed_body
+        greentea_ids = json['greenteas'].map { |r| r['id'] }
+        temple_ids = json['temples'].map { |r| r['id'] }
+        expect(greentea_ids).to include(near_greentea.id)
+        expect(greentea_ids).not_to include(far_greentea.id)
+        expect(temple_ids).to include(near_temple.id)
+        expect(temple_ids).not_to include(far_temple.id)
+      end
+
+      it 'returns flat snake_case fields with integer distance_meters' do
+        get '/api/v1/nearby', params: { lat: origin_lat, lng: origin_lng }
+
+        json = response.parsed_body
+        json['greenteas'].each do |g|
+          expect(g).to include('id', 'name', 'latitude', 'longitude', 'distance_meters')
+          expect(g['distance_meters']).to be_a(Integer)
+        end
+        json['temples'].each do |t|
+          expect(t).to include('id', 'name', 'latitude', 'longitude', 'distance_meters')
+          expect(t['distance_meters']).to be_a(Integer)
+        end
+      end
+
+      it 'orders each array by distance_meters ascending' do
+        # 既存 near と原点の間に位置するもう一件を追加して順序を確認
+        nearer_greentea = create(:greentea, latitude: origin_lat, longitude: origin_lng)
+        nearer_temple = create(:temple, latitude: origin_lat, longitude: origin_lng)
+
+        get '/api/v1/nearby', params: { lat: origin_lat, lng: origin_lng }
+
+        json = response.parsed_body
+        greentea_distances = json['greenteas'].map { |g| g['distance_meters'] }
+        temple_distances = json['temples'].map { |t| t['distance_meters'] }
+        expect(greentea_distances).to eq(greentea_distances.sort)
+        expect(temple_distances).to eq(temple_distances.sort)
+        expect(json['greenteas'].first['id']).to eq(nearer_greentea.id)
+        expect(json['temples'].first['id']).to eq(nearer_temple.id)
+      end
+
+      it 'respects custom radius parameter' do
+        # 5km 弱離れた地点を作成し、radius=1.5 では含まれず radius=10 では含まれることを確認
+        mid_greentea = create(:greentea, latitude: 35.00000, longitude: 135.80000)
+
+        get '/api/v1/nearby', params: { lat: origin_lat, lng: origin_lng, radius: 1.5 }
+        expect(response.parsed_body['greenteas'].map { |r| r['id'] }).not_to include(mid_greentea.id)
+
+        get '/api/v1/nearby', params: { lat: origin_lat, lng: origin_lng, radius: 10 }
+        expect(response.parsed_body['greenteas'].map { |r| r['id'] }).to include(mid_greentea.id)
+      end
+
+      it 'computes distance_meters consistent with Geokit' do
+        get '/api/v1/nearby', params: { lat: origin_lat, lng: origin_lng }
+
+        origin = Geokit::LatLng.new(origin_lat, origin_lng)
+        expected = (origin.distance_to(Geokit::LatLng.new(near_greentea.latitude, near_greentea.longitude)) * 1000).round
+        actual = response.parsed_body['greenteas'].find { |g| g['id'] == near_greentea.id }['distance_meters']
+        expect(actual).to be_within(5).of(expected)
+      end
+
+      it 'caps each array at 50 results' do
+        stub_const('Api::V1::NearbyController::MAX_RESULTS', 2)
+        create_list(:greentea, 4, latitude: origin_lat, longitude: origin_lng)
+
+        get '/api/v1/nearby', params: { lat: origin_lat, lng: origin_lng }
+
+        expect(response.parsed_body['greenteas'].size).to eq(2)
+      end
+    end
+
+    context 'with invalid parameters' do
+      it 'returns 400 when lat is non-numeric' do
+        get '/api/v1/nearby', params: { lat: 'abc', lng: origin_lng }
+
+        expect(response).to have_http_status(:bad_request)
+        expect(response.parsed_body).to eq('error' => 'Bad Request')
+      end
+
+      it 'returns 400 when lng is non-numeric' do
+        get '/api/v1/nearby', params: { lat: origin_lat, lng: 'xyz' }
+
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'returns 400 when lat is missing' do
+        get '/api/v1/nearby', params: { lng: origin_lng }
+
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'returns 400 when lng is missing' do
+        get '/api/v1/nearby', params: { lat: origin_lat }
+
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'returns 400 when lat is out of range' do
+        get '/api/v1/nearby', params: { lat: 200, lng: origin_lng }
+
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'returns 400 when lng is out of range' do
+        get '/api/v1/nearby', params: { lat: origin_lat, lng: -200 }
+
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'returns 400 when radius is non-numeric' do
+        get '/api/v1/nearby', params: { lat: origin_lat, lng: origin_lng, radius: 'foo' }
+
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'returns 400 when radius is zero or negative' do
+        get '/api/v1/nearby', params: { lat: origin_lat, lng: origin_lng, radius: 0 }
+
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'returns 400 when radius exceeds the maximum' do
+        get '/api/v1/nearby', params: { lat: origin_lat, lng: origin_lng, radius: 100 }
+
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+
+    context 'when no spots are within radius' do
+      it 'returns empty arrays' do
+        create(:greentea, latitude: 40.0, longitude: 140.0)
+        create(:temple, latitude: 40.0, longitude: 140.0)
+
+        get '/api/v1/nearby', params: { lat: origin_lat, lng: origin_lng }
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json['greenteas']).to eq([])
+        expect(json['temples']).to eq([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Closes #117

現在地から半径 N km 以内の抹茶店・神社をまとめて返す `GET /api/v1/nearby` を実装した。
フロント matcha-to-jinja の `NearbyMap` （matcha-to-jinja#17）から実 API でそのまま叩ける契約。

```
GET /api/v1/nearby?lat=34.9676&lng=135.7741&radius=1.5
```

### レスポンス例

```json
{
  "greenteas": [
    { "id": 1, "name": "...", "latitude": 34.9676, "longitude": 135.7741, "distance_meters": 0 }
  ],
  "temples": [
    { "id": 3, "name": "...", "latitude": 34.9678, "longitude": 135.7742, "distance_meters": 28 }
  ]
}
```

## 実装方針

- `Api::V1::NearbyController#search` を追加（未認証アクセス可）
- `Greentea` / `Temple` ともに `acts_as_mappable` が入っているので `within(radius, origin:).by_distance(origin:)` で距離付き・距離昇順のスコープを構築し、各 50 件で打ち切り
- 距離計算は既存の `NearbyGreenteaSerializer` / `NearbyTempleSerializer` をそのまま再利用（`obj.distance` が `within` から伝搬する）
- `lat` / `lng` のパースは `Float()` の例外ベース。`nil` / 数値以外 / 非有限 / 範囲外（`|lat| > 90` / `|lng| > 180`）は 400
- `radius` 省略時は **1.5km**、上限 **10km**。0 以下や上限超過は 400
- 結果なしは `{"greenteas": [], "temples": []}`

## 確認方法

```bash
bundle exec rspec spec/requests/api/v1/nearby_spec.rb
```

ローカルで疎通確認:

```bash
bin/rails server -p 3001
curl 'http://localhost:3001/api/v1/nearby?lat=34.9676&lng=135.7741'
curl 'http://localhost:3001/api/v1/nearby?lat=34.9676&lng=135.7741&radius=5'
curl -i 'http://localhost:3001/api/v1/nearby?lat=abc&lng=135.7741'   # → 400
```

## 影響範囲

- 新規エンドポイント追加のみ。既存 Web 画面 / 他の API には影響なし
- `Api::V1::BaseController` の `flatten_serialized` / `render_bad_request` を流用しており、共通基盤に変更はない

## チェックリスト

- [x] request spec を追加（正常系 / 異常系 / ソート / 半径 / 上限 50 件 / 空配列）
- [x] フロントの `docs/migration-plan.md` 1-3 のレスポンス契約と一致
- [x] 既存 `NearbyGreenteaSerializer` / `NearbyTempleSerializer` を再利用

## コメント

- 50 件打ち切りは `MAX_RESULTS` 定数で保護しており、spec では `stub_const` で 2 件に絞って検証
- `radius` 上限 10km はパフォーマンス保護の目安。フロント要件が変われば後続で調整可能

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCgwcj6oMkbCgnWYvX1sbP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a nearby location search API endpoint accepting latitude, longitude, and optional radius parameters, returning nearby places sorted by distance with automatic result limiting and distance calculations.

* **Tests**
  * Added comprehensive request tests covering valid inputs, validation edge cases, and distance computation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->