### PR TITLE
ci: GitHub Actions を commit SHA でピン留めし Dependabot を導入

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Dependabot 設定
+# - github-actions: SHA ピン留めしたワークフローを週次で更新追従する（#138）
+# - bundler: Gemfile.lock を週次で更新追従する
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
     name: RuboCop
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@12fd324f1d0b43274fdc8130f6980590a667c455 # v1.312.0
         with:
           ruby-version: .ruby-version
           bundler-cache: true
@@ -55,12 +55,12 @@ jobs:
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/greentea_temple_test
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@12fd324f1d0b43274fdc8130f6980590a667c455 # v1.312.0
         with:
           ruby-version: .ruby-version
           bundler-cache: true
@@ -97,18 +97,18 @@ jobs:
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/greentea_temple_test
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@12fd324f1d0b43274fdc8130f6980590a667c455 # v1.312.0
         with:
           ruby-version: .ruby-version
           bundler-cache: true
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 18
           cache: yarn
@@ -126,7 +126,7 @@ jobs:
       # Chrome 本体をセットアップする。chromedriver は selenium-webdriver 4.11+ の
       # Selenium Manager が自動解決するため、別途インストールは不要（#134）
       - name: Set up Chrome
-        uses: browser-actions/setup-chrome@v1
+        uses: browser-actions/setup-chrome@c785b87e244131f27c9f19c1a33e2ead956ab7ce # v1.7.3
         with:
           chrome-version: stable
 


### PR DESCRIPTION
Closes #138

## 概要

`.github/workflows/ci.yml` の `uses:` をタグ参照（`@v4` / `@v1`）からフルコミット SHA（40 桁）に置き換え、サプライチェーンのドリフトリスク（zizmor の `unpinned-uses`）に対応した。あわせて `.github/dependabot.yml` を新規作成し、SHA ピン留めが陳腐化しないよう週次で追従する仕組みを入れた。

## 変更内容

### `.github/workflows/ci.yml`

`uses:` 8 箇所をすべてフル SHA に固定し、行末コメントで対応バージョンを併記。

| Action | バージョン | SHA |
|---|---|---|
| `actions/checkout` | v4.3.1 | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `ruby/setup-ruby` | v1.312.0 | `12fd324f1d0b43274fdc8130f6980590a667c455` |
| `actions/setup-node` | v4.4.0 | `49933ea5288caeca8642d1e84afbd3f7d6820020` |
| `browser-actions/setup-chrome` | v1.7.3 | `c785b87e244131f27c9f19c1a33e2ead956ab7ce` |

> 既存ワークフローが指していた major（v4 / v1）の最新 patch を採用。major ジャンプ（v5/v6 等）は別途 Dependabot PR で対応する想定。

### `.github/dependabot.yml`（新規）

- `github-actions` エコシステムを週次で追従（SHA ピン留めでも行末コメントを読み取って PR を作ってくれる）
- 追加で `bundler` も週次に設定（issue の補足コメント記載どおり）

## 受け入れ条件の確認

- [x] `ci.yml` の全 `uses:` がフル SHA（40 桁）でピン留めされている
- [x] 各行にバージョンの行末コメントが付いている
- [x] `.github/dependabot.yml` に `github-actions` の更新設定が入っている
- [ ] CI（RuboCop / RSpec / system）が緑のまま → PR 上で確認

---
_Generated by [Claude Code](https://claude.ai/code/session_011pwkFwkLbEFKVQGuCqk8rq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established automated weekly dependency scanning and update notifications for GitHub Actions and package managers to enhance security and maintain library currency
  * Locked continuous integration workflow action versions to specific commit hashes to improve overall build reproducibility, consistency, stability, and long-term pipeline reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->