### PR TITLE
chore: rack を 2.2 系にピン留めし Rack 3 連鎖アップを防ぐ

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,10 @@ gem "pg", "~> 1.1"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", "~> 5.0"
 
+# Rack 3 は capybara 3.40 + puma 5 と非互換（rack/handler 削除）。
+# Rack 3 化は puma 6 / capybara 更新と合わせて別途対応する。
+gem "rack", "~> 2.2"
+
 # Bundle and transpile JavaScript [https://github.com/rails/jsbundling-rails]
 gem "jsbundling-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -548,6 +548,7 @@ DEPENDENCIES
   pg (~> 1.1)
   pry-byebug
   puma (~> 5.0)
+  rack (~> 2.2)
   rack-cors
   rails (~> 7.1.0)
   rails-i18n


### PR DESCRIPTION
## 概要

Dependabot の依存更新 PR (#144 jsbundling-rails / #145 geokit-rails) で `rack` が 2.2.23 → 3.x にカスケードアップグレードされ、CI の system spec が全件 `LoadError: cannot load such file -- rack/handler` で落ちていた。

これは Rack 3 で `rack/handler` が削除（rackup gem へ分離）された一方、

- capybara 3.40 が `require 'rack/handler/puma'` を呼ぶ
- puma 5.6 の `rack/handler/puma.rb` が `require 'rack/handler'` を呼ぶ

ため、capybara + puma 5 系では Rack 3 を読み込めないことが原因。

本 PR では Gemfile に `gem 'rack', '~> 2.2'` を追加し、依存解決の際 rack が 2.2 系から動かないよう明示的にピン留めする。

## なぜピン留めで良いか

- 本リポジトリは Rails 7.1 系で稼働中（Rack 2.2 で全機能動作）
- Rack 3 への移行は puma 6 系 / capybara 更新と合わせて意図的に進めるべき変更で、Dependabot の通常依存更新に紛れて入れるべきではない
- 本番にも spec にも影響しない安全な変更

## 影響

- `Gemfile`: `gem 'rack', '~> 2.2'` を追加
- `Gemfile.lock`: `DEPENDENCIES` セクションに `rack (~> 2.2)` を追加（バージョン自体は 2.2.23 で変わらず）

## マージ後のフロー

1. main に取り込み
2. #144 / #145 に `@dependabot rebase` をコメントし、rack 2.x のまま再生成
3. CI 緑を確認してマージ

## テスト

- [ ] CI（RSpec request / model / helper, RSpec system, RuboCop）が緑になる
- [ ] 本番想定の Rack 2.2.23 で動作することを bundle install で確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeqbAGhEQbDdKu3aUVW6sZ)_