### PR TITLE
feat(infra): Cloud Run 用 Dockerfile + デプロイ workflow を追加 (#118)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,61 @@
+.git
+.github
+.gitignore
+.gitattributes
+
+# Local Bundler / Ruby state
+.bundle
+/vendor/bundle
+
+# Node / asset build artifacts（ビルドステージで再生成する）
+node_modules
+yarn-error.log
+yarn-debug.log*
+.yarn-integrity
+/app/assets/builds
+
+# Runtime artifacts
+/log/*
+/tmp/*
+!/log/.keep
+!/tmp/.keep
+!/tmp/pids/.keep
+/storage/*
+!/storage/.keep
+/public/assets
+/public/packs
+/public/packs-test
+/public/uploads
+
+# Tests / docs（コンテナに入れない）
+/spec
+/test
+.rspec
+/docs
+
+# Secrets
+/config/master.key
+/.env
+/.env.*
+config/settings.local.yml
+config/settings/*.local.yml
+config/environments/*.local.yml
+
+# Editor / OS
+.DS_Store
+.idea
+.vscode
+*.swp
+
+# Lint / CI 設定（コンテナでは使わない）
+.rubocop.yml
+.erb-lint.yml
+.byebug_history
+
+# Dev DB
+db/greentea_temple_development
+db/greentea_temple_test
+
+# Dockerfile 自身（自己参照を避ける）
+Dockerfile
+.dockerignore

--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -29,13 +29,19 @@ jobs:
           persist-credentials: false
 
       # inputs.image_tag を `run:` スクリプトに直接展開すると script injection
-      # の余地があるため、必ず env 経由で受け取る
+      # の余地があるため、必ず env 経由で受け取る。さらに Docker / OCI のタグ
+      # 仕様 (https://docs.docker.com/reference/cli/docker/image/tag/#description)
+      # に沿った形式かを正規表現で fail-fast 検証する
       - name: Resolve image tag
         id: tag
         env:
           INPUT_TAG: ${{ inputs.image_tag }}
         run: |
           if [ -n "${INPUT_TAG}" ]; then
+            if ! [[ "${INPUT_TAG}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+              echo "::error::Invalid image_tag: '${INPUT_TAG}'. Must match ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}\$" >&2
+              exit 1
+            fi
             echo "tag=${INPUT_TAG}" >> "$GITHUB_OUTPUT"
           else
             echo "tag=${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
@@ -85,35 +91,55 @@ jobs:
           docker push "${IMAGE_BASE}:${IMAGE_TAG}"
           docker push "${IMAGE_BASE}:latest"
 
+      # 環境変数名はアプリ実コードが ENV[..] で参照している名前に合わせている:
+      #   - GMAP_API           : config/initializers/geocoder.rb
+      #   - GOOGLE_MAP_API     : app/views/**/*.erb (Google Maps JS API key)
+      # CLAUDE.md 表記の `GOOGLE_GEOCODING_API_KEY` / `GOOGLE_MAPS_API_KEY`
+      # への統一は別タスクで実施する。
+      #
+      # SECRET_KEY_BASE は credentials.yml.enc に持たせる場合 RAILS_MASTER_KEY
+      # 経由で復号されるため不要。`secrets.SECRET_KEY_BASE` を unconditionally
+      # に渡すと secret 未設定時に空文字で credentials 由来の値を上書きして
+      # しまうため、secret が存在するときのみ env_vars に含める
+      - name: Compose Cloud Run env vars
+        id: env
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          FRONTEND_URL: ${{ vars.FRONTEND_URL }}
+          SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
+          JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
+          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+          GMAP_API: ${{ secrets.GMAP_API }}
+          GOOGLE_MAP_API: ${{ secrets.GOOGLE_MAP_API }}
+          LINE_KEY: ${{ secrets.LINE_KEY }}
+          LINE_SECRET: ${{ secrets.LINE_SECRET }}
+        run: |
+          {
+            echo "vars<<__ENV_EOF__"
+            echo "RAILS_ENV=production"
+            echo "DATABASE_URL=${DATABASE_URL}"
+            echo "FRONTEND_URL=${FRONTEND_URL}"
+            echo "JWT_SECRET_KEY=${JWT_SECRET_KEY}"
+            echo "RAILS_MASTER_KEY=${RAILS_MASTER_KEY}"
+            echo "GMAP_API=${GMAP_API}"
+            echo "GOOGLE_MAP_API=${GOOGLE_MAP_API}"
+            echo "LINE_KEY=${LINE_KEY}"
+            echo "LINE_SECRET=${LINE_SECRET}"
+            if [ -n "${SECRET_KEY_BASE}" ]; then
+              echo "SECRET_KEY_BASE=${SECRET_KEY_BASE}"
+            fi
+            echo "__ENV_EOF__"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Deploy to Cloud Run
-        # TODO(#118): SHA ピン
+        # TODO(#118): SHA ピン（v2 のリリース安定後に切替）
         uses: google-github-actions/deploy-cloudrun@v2
         with:
           service: ${{ env.SERVICE_NAME }}
           region: ${{ env.GCP_REGION }}
           image: ${{ steps.image.outputs.base }}:${{ steps.tag.outputs.tag }}
           flags: --allow-unauthenticated --memory=512Mi --cpu=1 --min-instances=0 --max-instances=4
-          # 実値はすべて GitHub の secrets / vars から渡す。Cloud Run のサービス
-          # 自体に保存される env vars はこの workflow で上書きされる点に注意。
-          # 環境変数名はアプリ実コードが ENV[..] で参照している名前に合わせている:
-          #   - GMAP_API           : config/initializers/geocoder.rb
-          #   - GOOGLE_MAP_API     : app/views/**/*.erb (Google Maps JS API key)
-          # CLAUDE.md 表記の `GOOGLE_GEOCODING_API_KEY` / `GOOGLE_MAPS_API_KEY`
-          # への統一は別タスクで実施する。
-          # SECRET_KEY_BASE は credentials.yml.enc に持たせる場合 RAILS_MASTER_KEY
-          # 経由で復号されるため不要だが、credentials に含まれていない構成だと
-          # 起動時に ArgumentError になるため、secrets に存在すれば明示的に渡す
-          env_vars: |
-            RAILS_ENV=production
-            DATABASE_URL=${{ secrets.DATABASE_URL }}
-            FRONTEND_URL=${{ vars.FRONTEND_URL }}
-            SECRET_KEY_BASE=${{ secrets.SECRET_KEY_BASE }}
-            JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
-            RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}
-            GMAP_API=${{ secrets.GMAP_API }}
-            GOOGLE_MAP_API=${{ secrets.GOOGLE_MAP_API }}
-            LINE_KEY=${{ secrets.LINE_KEY }}
-            LINE_SECRET=${{ secrets.LINE_SECRET }}
+          env_vars: ${{ steps.env.outputs.vars }}
 
       - name: Show service URL
         run: |

--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -23,10 +23,6 @@ jobs:
     name: Build & Deploy
     runs-on: ubuntu-latest
 
-    # IMAGE_BASE は build / push / deploy ステップで共有する
-    env:
-      IMAGE_BASE: asia-northeast1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ vars.AR_REPOSITORY }}/greentea-temple
-
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -45,6 +41,17 @@ jobs:
             echo "tag=${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
           fi
 
+      # GitHub Actions の `jobs.<job_id>.env` では `secrets` コンテキストが
+      # 参照できない（github / needs / strategy / matrix / vars / inputs のみ）。
+      # IMAGE_BASE は GCP_PROJECT_ID（secret）を含むため、step output で組み立てる
+      - name: Compose image base
+        id: image
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          AR_REPOSITORY: ${{ vars.AR_REPOSITORY }}
+        run: |
+          echo "base=${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${AR_REPOSITORY}/${SERVICE_NAME}" >> "$GITHUB_OUTPUT"
+
       - name: Authenticate to Google Cloud
         # TODO(#118): 安定後に SHA ピンする。現状は機能確認のため v2 タグを使用
         uses: google-github-actions/auth@v2
@@ -61,6 +68,7 @@ jobs:
 
       - name: Build image
         env:
+          IMAGE_BASE: ${{ steps.image.outputs.base }}
           IMAGE_TAG: ${{ steps.tag.outputs.tag }}
         run: |
           docker build \
@@ -71,6 +79,7 @@ jobs:
 
       - name: Push image
         env:
+          IMAGE_BASE: ${{ steps.image.outputs.base }}
           IMAGE_TAG: ${{ steps.tag.outputs.tag }}
         run: |
           docker push "${IMAGE_BASE}:${IMAGE_TAG}"
@@ -82,7 +91,7 @@ jobs:
         with:
           service: ${{ env.SERVICE_NAME }}
           region: ${{ env.GCP_REGION }}
-          image: ${{ env.IMAGE_BASE }}:${{ steps.tag.outputs.tag }}
+          image: ${{ steps.image.outputs.base }}:${{ steps.tag.outputs.tag }}
           flags: --allow-unauthenticated --memory=512Mi --cpu=1 --min-instances=0 --max-instances=4
           # 実値はすべて GitHub の secrets / vars から渡す。Cloud Run のサービス
           # 自体に保存される env vars はこの workflow で上書きされる点に注意。

--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -79,14 +79,19 @@ jobs:
           flags: --allow-unauthenticated --memory=512Mi --cpu=1 --min-instances=0 --max-instances=4
           # 実値はすべて GitHub の secrets / vars から渡す。Cloud Run のサービス
           # 自体に保存される env vars はこの workflow で上書きされる点に注意。
+          # 環境変数名はアプリ実コードが ENV[..] で参照している名前に合わせている:
+          #   - GMAP_API           : config/initializers/geocoder.rb
+          #   - GOOGLE_MAP_API     : app/views/**/*.erb (Google Maps JS API key)
+          # CLAUDE.md 表記の `GOOGLE_GEOCODING_API_KEY` / `GOOGLE_MAPS_API_KEY`
+          # への統一は別タスクで実施する。
           env_vars: |
             RAILS_ENV=production
             DATABASE_URL=${{ secrets.DATABASE_URL }}
             FRONTEND_URL=${{ vars.FRONTEND_URL }}
             JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
             RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}
-            GOOGLE_GEOCODING_API_KEY=${{ secrets.GOOGLE_GEOCODING_API_KEY }}
-            GOOGLE_MAPS_API_KEY=${{ secrets.GOOGLE_MAPS_API_KEY }}
+            GMAP_API=${{ secrets.GMAP_API }}
+            GOOGLE_MAP_API=${{ secrets.GOOGLE_MAP_API }}
             LINE_KEY=${{ secrets.LINE_KEY }}
             LINE_SECRET=${{ secrets.LINE_SECRET }}
 

--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -23,16 +23,24 @@ jobs:
     name: Build & Deploy
     runs-on: ubuntu-latest
 
+    # IMAGE_BASE は build / push / deploy ステップで共有する
+    env:
+      IMAGE_BASE: asia-northeast1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ vars.AR_REPOSITORY }}/greentea-temple
+
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
+      # inputs.image_tag を `run:` スクリプトに直接展開すると script injection
+      # の余地があるため、必ず env 経由で受け取る
       - name: Resolve image tag
         id: tag
+        env:
+          INPUT_TAG: ${{ inputs.image_tag }}
         run: |
-          if [ -n "${{ inputs.image_tag }}" ]; then
-            echo "tag=${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
+          if [ -n "${INPUT_TAG}" ]; then
+            echo "tag=${INPUT_TAG}" >> "$GITHUB_OUTPUT"
           else
             echo "tag=${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
           fi
@@ -53,21 +61,20 @@ jobs:
 
       - name: Build image
         env:
-          IMAGE_BASE: ${{ env.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ vars.AR_REPOSITORY }}/${{ env.SERVICE_NAME }}
           IMAGE_TAG: ${{ steps.tag.outputs.tag }}
         run: |
           docker build \
-            --tag "$IMAGE_BASE:$IMAGE_TAG" \
-            --tag "$IMAGE_BASE:latest" \
+            --tag "${IMAGE_BASE}:${IMAGE_TAG}" \
+            --tag "${IMAGE_BASE}:latest" \
+            --cache-from "${IMAGE_BASE}:latest" \
             .
 
       - name: Push image
         env:
-          IMAGE_BASE: ${{ env.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ vars.AR_REPOSITORY }}/${{ env.SERVICE_NAME }}
           IMAGE_TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          docker push "$IMAGE_BASE:$IMAGE_TAG"
-          docker push "$IMAGE_BASE:latest"
+          docker push "${IMAGE_BASE}:${IMAGE_TAG}"
+          docker push "${IMAGE_BASE}:latest"
 
       - name: Deploy to Cloud Run
         # TODO(#118): SHA ピン
@@ -75,7 +82,7 @@ jobs:
         with:
           service: ${{ env.SERVICE_NAME }}
           region: ${{ env.GCP_REGION }}
-          image: ${{ env.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ vars.AR_REPOSITORY }}/${{ env.SERVICE_NAME }}:${{ steps.tag.outputs.tag }}
+          image: ${{ env.IMAGE_BASE }}:${{ steps.tag.outputs.tag }}
           flags: --allow-unauthenticated --memory=512Mi --cpu=1 --min-instances=0 --max-instances=4
           # 実値はすべて GitHub の secrets / vars から渡す。Cloud Run のサービス
           # 自体に保存される env vars はこの workflow で上書きされる点に注意。
@@ -84,10 +91,14 @@ jobs:
           #   - GOOGLE_MAP_API     : app/views/**/*.erb (Google Maps JS API key)
           # CLAUDE.md 表記の `GOOGLE_GEOCODING_API_KEY` / `GOOGLE_MAPS_API_KEY`
           # への統一は別タスクで実施する。
+          # SECRET_KEY_BASE は credentials.yml.enc に持たせる場合 RAILS_MASTER_KEY
+          # 経由で復号されるため不要だが、credentials に含まれていない構成だと
+          # 起動時に ArgumentError になるため、secrets に存在すれば明示的に渡す
           env_vars: |
             RAILS_ENV=production
             DATABASE_URL=${{ secrets.DATABASE_URL }}
             FRONTEND_URL=${{ vars.FRONTEND_URL }}
+            SECRET_KEY_BASE=${{ secrets.SECRET_KEY_BASE }}
             JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
             RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}
             GMAP_API=${{ secrets.GMAP_API }}

--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -1,0 +1,97 @@
+name: Deploy to Cloud Run
+
+# 当面は手動トリガのみ。Workload Identity Federation / 各 secrets / vars が
+# 揃ったタイミングで `push: branches: [main]` を有効化する想定（#118）。
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "デプロイするイメージタグ（未指定なら commit SHA の先頭 12 桁）"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  id-token: write # Workload Identity Federation
+
+env:
+  GCP_REGION: asia-northeast1
+  SERVICE_NAME: greentea-temple
+
+jobs:
+  deploy:
+    name: Build & Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Resolve image tag
+        id: tag
+        run: |
+          if [ -n "${{ inputs.image_tag }}" ]; then
+            echo "tag=${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Authenticate to Google Cloud
+        # TODO(#118): 安定後に SHA ピンする。現状は機能確認のため v2 タグを使用
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_DEPLOY_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        # TODO(#118): SHA ピン
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev --quiet
+
+      - name: Build image
+        env:
+          IMAGE_BASE: ${{ env.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ vars.AR_REPOSITORY }}/${{ env.SERVICE_NAME }}
+          IMAGE_TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          docker build \
+            --tag "$IMAGE_BASE:$IMAGE_TAG" \
+            --tag "$IMAGE_BASE:latest" \
+            .
+
+      - name: Push image
+        env:
+          IMAGE_BASE: ${{ env.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ vars.AR_REPOSITORY }}/${{ env.SERVICE_NAME }}
+          IMAGE_TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          docker push "$IMAGE_BASE:$IMAGE_TAG"
+          docker push "$IMAGE_BASE:latest"
+
+      - name: Deploy to Cloud Run
+        # TODO(#118): SHA ピン
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ env.SERVICE_NAME }}
+          region: ${{ env.GCP_REGION }}
+          image: ${{ env.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ vars.AR_REPOSITORY }}/${{ env.SERVICE_NAME }}:${{ steps.tag.outputs.tag }}
+          flags: --allow-unauthenticated --memory=512Mi --cpu=1 --min-instances=0 --max-instances=4
+          # 実値はすべて GitHub の secrets / vars から渡す。Cloud Run のサービス
+          # 自体に保存される env vars はこの workflow で上書きされる点に注意。
+          env_vars: |
+            RAILS_ENV=production
+            DATABASE_URL=${{ secrets.DATABASE_URL }}
+            FRONTEND_URL=${{ vars.FRONTEND_URL }}
+            JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
+            RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}
+            GOOGLE_GEOCODING_API_KEY=${{ secrets.GOOGLE_GEOCODING_API_KEY }}
+            GOOGLE_MAPS_API_KEY=${{ secrets.GOOGLE_MAPS_API_KEY }}
+            LINE_KEY=${{ secrets.LINE_KEY }}
+            LINE_SECRET=${{ secrets.LINE_SECRET }}
+
+      - name: Show service URL
+        run: |
+          gcloud run services describe ${{ env.SERVICE_NAME }} \
+            --region ${{ env.GCP_REGION }} \
+            --format='value(status.url)'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,95 @@
+# syntax=docker/dockerfile:1.7
+
+ARG RUBY_VERSION=3.3.11
+ARG NODE_MAJOR=18
+
+# ---------- build stage ----------
+FROM ruby:${RUBY_VERSION}-slim AS build
+
+ARG NODE_MAJOR
+
+ENV RAILS_ENV=production \
+    BUNDLE_DEPLOYMENT=1 \
+    BUNDLE_PATH=/usr/local/bundle \
+    BUNDLE_WITHOUT="development:test"
+
+WORKDIR /app
+
+# Native gems (pg / mini_magick) と asset build に必要なツールを入れる
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+      build-essential \
+      ca-certificates \
+      curl \
+      git \
+      gnupg \
+      libpq-dev \
+      libvips \
+      pkg-config && \
+    rm -rf /var/lib/apt/lists/*
+
+# Node.js + Yarn（jsbundling-rails / cssbundling-rails 用）
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    npm install -g yarn && \
+    rm -rf /var/lib/apt/lists/*
+
+# Gem を先に解決（Gemfile が変わらない限りキャッシュが効く）
+COPY Gemfile Gemfile.lock ./
+RUN bundle install --jobs 4 --retry 3 && \
+    rm -rf /usr/local/bundle/cache
+
+# JS deps
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+
+# アプリ全体
+COPY . .
+
+# Bootsnap precompile（起動時間短縮）
+RUN bundle exec bootsnap precompile --gemfile app/ lib/ config/
+
+# Asset precompile。SECRET_KEY_BASE はビルド時のダミーで十分
+RUN SECRET_KEY_BASE=dummy bundle exec rails assets:precompile && \
+    rm -rf node_modules tmp/cache vendor/cache
+
+# ---------- runtime stage ----------
+FROM ruby:${RUBY_VERSION}-slim AS runtime
+
+ENV RAILS_ENV=production \
+    RAILS_LOG_TO_STDOUT=1 \
+    RAILS_SERVE_STATIC_FILES=1 \
+    BUNDLE_DEPLOYMENT=1 \
+    BUNDLE_PATH=/usr/local/bundle \
+    BUNDLE_WITHOUT="development:test" \
+    PORT=8080
+
+WORKDIR /app
+
+# Runtime に必要なライブラリのみ（コンパイラは入れない）
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      libjemalloc2 \
+      libpq5 \
+      libvips \
+      tzdata && \
+    rm -rf /var/lib/apt/lists/*
+
+# 非 root ユーザで起動
+RUN groupadd --system --gid 1000 app && \
+    useradd --system --uid 1000 --gid app --home-dir /app --shell /usr/sbin/nologin app
+
+COPY --from=build --chown=app:app /usr/local/bundle /usr/local/bundle
+COPY --from=build --chown=app:app /app /app
+
+# tmp / log は実行時のみ書き込み可能にする
+RUN mkdir -p tmp/pids log && chown -R app:app tmp log
+
+USER app
+
+EXPOSE 8080
+
+# Cloud Run は $PORT をコンテナに渡してくる。0.0.0.0 で listen する必要がある
+CMD ["bash", "-lc", "bundle exec rails server -b 0.0.0.0 -p ${PORT}"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ ENV RAILS_ENV=production \
     BUNDLE_DEPLOYMENT=1 \
     BUNDLE_PATH=/usr/local/bundle \
     BUNDLE_WITHOUT="development:test" \
+    LD_PRELOAD=libjemalloc.so.2 \
     PORT=8080
 
 WORKDIR /app
@@ -91,5 +92,7 @@ USER app
 
 EXPOSE 8080
 
-# Cloud Run は $PORT をコンテナに渡してくる。0.0.0.0 で listen する必要がある
-CMD ["bash", "-lc", "bundle exec rails server -b 0.0.0.0 -p ${PORT}"]
+# Cloud Run は $PORT をコンテナに渡してくる。0.0.0.0 で listen する必要がある。
+# `exec` を付けて Rails プロセスを PID 1 にし、Cloud Run の SIGTERM が
+# 正しく届くようにする
+CMD ["bash", "-c", "exec bundle exec rails server -b 0.0.0.0 -p ${PORT}"]


### PR DESCRIPTION
## 概要

GCP Cloud Run + Neon PostgreSQL デプロイ (#118) の **最初の一歩** として、本番コンテナイメージのビルド経路と Cloud Run へのデプロイ workflow を追加します。Refs #118

> [!IMPORTANT]
> 本 PR は **「コードに閉じる」サブセット** です。`#118` の以下の項目は **対象外**（後続 PR / ユーザー側の環境作業）:
> - GCP プロジェクト / Artifact Registry / Workload Identity Federation のセットアップ
> - Neon PostgreSQL のアカウント作成 + Heroku からのデータ移行
> - Cloud Storage バケット作成 + CarrierWave (`fog-google`) への切替 + 画像移行
> - カスタムドメイン (`api.matcha-to-jinja.com`) + SSL
> - `push: branches: [main]` でのオートデプロイ有効化
>
> これらは secrets / 実環境がない状態で書いても動作確認できないため、ユーザー側の環境準備が整ったタイミングで段階的に PR を分けて対応します。

### 変更内容

- **`Dockerfile`**（multi-stage）
  - **build stage**: `ruby:3.3.11-slim` + Node.js 18 をベースに `bundle install` → `yarn install` → `bootsnap precompile` → `assets:precompile` を実施
  - **runtime stage**: `libpq5` / `libvips` / `tzdata` だけを含む軽量イメージ。非 root ユーザ (`app`) で起動
  - Cloud Run の `$PORT`（既定 8080）を 0.0.0.0 で listen
  - `SECRET_KEY_BASE` はビルド時のみダミー値（本番値は Cloud Run env vars 経由）
- **`.dockerignore`**: `spec/` / `docs/` / `node_modules` / 秘密情報 / 開発用 DB / lint 設定など、ビルドステージで不要な or 入ってはいけないファイルを除外
- **`.github/workflows/deploy-cloud-run.yml`**: 当面は `workflow_dispatch` のみ（main push でのオートデプロイは Workload Identity Federation + secrets が揃ってから別 PR で有効化）
  - Workload Identity Federation で GCP に認証（鍵レス）
  - Artifact Registry に push → Cloud Run に deploy（`--allow-unauthenticated --memory=512Mi --cpu=1 --min-instances=0 --max-instances=4`）
  - 環境変数は `secrets` / `vars` から渡す: `DATABASE_URL` / `FRONTEND_URL` / `JWT_SECRET_KEY` / `RAILS_MASTER_KEY` / `GOOGLE_*_API_KEY` / `LINE_KEY` / `LINE_SECRET`

## 確認方法

> [!NOTE]
> ローカルで Docker daemon があれば下記でビルド確認できます。GCP リソースなしで動かせる範囲のみ記載。

### 1. ビルドできること

```bash
docker build -t greentea-temple:local .
```

### 2. ローカル起動（DB は別途必要）

```bash
docker run --rm -p 8080:8080 \
  -e SECRET_KEY_BASE=$(bin/rails secret) \
  -e RAILS_MASTER_KEY=$(cat config/master.key) \
  -e DATABASE_URL=postgres://user:pass@host.docker.internal:5432/db \
  greentea-temple:local

curl http://localhost:8080/api/v1/health
```

### 3. CI 上で workflow が表示されること

PR マージ後に Actions タブに `Deploy to Cloud Run` が出現し、`workflow_dispatch` から手動実行できる状態になります（secrets が無いと実際の deploy は失敗します）。

## 影響範囲

- **既存の CI (`ci.yml`) には影響なし**: `deploy-cloud-run.yml` は別 workflow として追加
- **既存の `bin/dev` / ローカル開発フロー**: 変更なし
- **本番デプロイ動作**: secrets / GCP リソースが未設定のため、merge してもオートデプロイは走らない（手動 workflow のみ）

## 着手前にユーザー側で必要になる作業（次フェーズ）

本 PR マージ後、デプロイを実際に動かすためには以下が必要です（順次別 PR / 手順で進めます）:

1. **GCP**
   - プロジェクト作成（`asia-northeast1`）
   - Artifact Registry リポジトリ作成
   - Workload Identity Federation: GitHub Actions 用 Provider + Service Account 設定
   - Cloud Run サービス初回作成（workflow からも作れるが、ドメインマッピング等は手動）
2. **Neon PostgreSQL**: アカウント / プロジェクト / 開発・本番ブランチ
3. **GitHub secrets / vars**
   - secrets: `GCP_PROJECT_ID`, `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_DEPLOY_SERVICE_ACCOUNT`, `DATABASE_URL`, `JWT_SECRET_KEY`, `RAILS_MASTER_KEY`, `GOOGLE_GEOCODING_API_KEY`, `GOOGLE_MAPS_API_KEY`, `LINE_KEY`, `LINE_SECRET`
   - vars: `AR_REPOSITORY`, `FRONTEND_URL`
4. **Cloud Storage バケット** + CarrierWave 切替（別 PR）

## チェックリスト

- [x] Multi-stage Dockerfile で runtime に build tool を含めない
- [x] 非 root ユーザで起動
- [x] `assets:precompile` をビルド時に実行（dummy `SECRET_KEY_BASE`）
- [x] `.dockerignore` で `spec` / `docs` / 秘密情報を除外
- [x] workflow は当面 `workflow_dispatch` のみ（誤デプロイ防止）
- [ ] GCP リソース整備（別 PR / ユーザー作業）
- [ ] secrets / vars の登録（ユーザー作業）

## コメント

- `google-github-actions/auth` / `setup-gcloud` / `deploy-cloudrun` は当面 `@v2` タグを使っています。安定後に SHA ピンする想定です（既存 CI と同じスタイルにする）。
- 既存 `app/views/*` が残っている期間は asset precompile が必要なため、Dockerfile では `yarn build` を含む `assets:precompile` を実行しています。Web フロント撤去 (#136) 完了後は build stage から Node 一式を外せます。
- CarrierWave の `:local` → GCS 切替は本 PR では行いません。`production.rb` の `config.active_storage.service = :local` も今は変更しません。


---
_Generated by [Claude Code](https://claude.ai/code/session_018ePxn3gFuTf6bsXMcLTC66)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented multi-stage Docker containerization for production builds with optimized asset precompilation and secure non-root execution
  * Established automated deployment pipeline with manual trigger capability and environment configuration management
  * Configured build context optimization to exclude unnecessary artifacts, metadata, and development files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->