### PR TITLE
feat: モデルルート作成機能の API を追加 (#65)

### DIFF
--- a/app/controllers/api/v1/routes_controller.rb
+++ b/app/controllers/api/v1/routes_controller.rb
@@ -1,0 +1,108 @@
+module Api
+  module V1
+    class RoutesController < BaseController
+      # 不正なスポット指定（存在しない spot / 未対応の spot_type / 不正な transport）を表す。
+      class InvalidSpotError < StandardError; end
+
+      before_action :require_authentication!
+
+      def index
+        scope = current_user.routes.order(created_at: :desc)
+        paginated = paginate(scope).load
+        spot_counts = RouteSpot.where(route_id: paginated.map(&:id)).group(:route_id).count
+
+        render_collection(
+          paginated,
+          serializer: RouteSerializer,
+          serializer_params: { spot_counts: spot_counts }
+        )
+      end
+
+      def show
+        route = current_user.routes.includes(route_spots: :spottable).find(params[:id])
+        render_route_detail(route)
+      end
+
+      def create
+        route = current_user.routes.new(name: route_params[:name], description: route_params[:description])
+
+        ActiveRecord::Base.transaction do
+          build_spots(route, spots_params)
+          route.save!
+        end
+
+        render_route_detail(route, status: :created)
+      rescue ActiveRecord::RecordInvalid => e
+        render_unprocessable(e.record.errors.full_messages)
+      rescue InvalidSpotError => e
+        render_unprocessable([e.message])
+      end
+
+      def update
+        route = current_user.routes.find(params[:id])
+
+        ActiveRecord::Base.transaction do
+          route.assign_attributes(name: route_params[:name], description: route_params[:description])
+          route.route_spots.destroy_all
+          build_spots(route, spots_params)
+          route.save!
+        end
+
+        render_route_detail(route.reload)
+      rescue ActiveRecord::RecordInvalid => e
+        render_unprocessable(e.record.errors.full_messages)
+      rescue InvalidSpotError => e
+        render_unprocessable([e.message])
+      end
+
+      def destroy
+        route = current_user.routes.find(params[:id])
+        route.destroy!
+        head :no_content
+      end
+
+      private
+
+      def route_params
+        params.require(:route).permit(:name, :description, spots: %i[spot_type spot_id transport])
+      end
+
+      def spots_params
+        route_params[:spots] || []
+      end
+
+      # API の spots 配列（順序 = ルート順）から polymorphic な RouteSpot を組み立てる。
+      def build_spots(route, spots)
+        spots.each_with_index do |spot, index|
+          spottable_type = RouteSpot.spottable_type_for(spot[:spot_type])
+          raise InvalidSpotError, "invalid spot_type: #{spot[:spot_type]}" unless spottable_type
+
+          record = spottable_type.constantize.find_by(id: spot[:spot_id])
+          raise InvalidSpotError, "#{spot[:spot_type]} ##{spot[:spot_id]} not found" unless record
+
+          route.route_spots.build(
+            spottable: record,
+            position: index + 1,
+            transport: normalize_transport(spot[:transport])
+          )
+        end
+      end
+
+      def normalize_transport(value)
+        return nil if value.blank?
+        return value.to_s if RouteSpot.transports.key?(value.to_s)
+
+        raise InvalidSpotError, "invalid transport: #{value}"
+      end
+
+      def render_route_detail(route, status: :ok)
+        serialized = RouteDetailSerializer.new(route).serializable_hash
+        render json: { data: flatten_one(serialized[:data]) }, status: status
+      end
+
+      def render_unprocessable(messages)
+        render json: { error: 'Unprocessable Entity', details: messages }, status: :unprocessable_entity
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/routes_controller.rb
+++ b/app/controllers/api/v1/routes_controller.rb
@@ -24,7 +24,7 @@ module Api
       end
 
       def create
-        route = current_user.routes.new(name: route_params[:name], description: route_params[:description])
+        route = current_user.routes.new(scalar_params)
 
         ActiveRecord::Base.transaction do
           build_spots(route, spots_params)
@@ -42,9 +42,13 @@ module Api
         route = current_user.routes.find(params[:id])
 
         ActiveRecord::Base.transaction do
-          route.assign_attributes(name: route_params[:name], description: route_params[:description])
-          route.route_spots.destroy_all
-          build_spots(route, spots_params)
+          route.assign_attributes(scalar_params)
+          # spots は明示的に渡されたときだけ総入れ替えする。
+          # 省略時は既存スポットを保持し、name/description のみの部分更新を許す。
+          if route_params.key?(:spots)
+            route.route_spots.destroy_all
+            build_spots(route, spots_params)
+          end
           route.save!
         end
 
@@ -65,6 +69,11 @@ module Api
 
       def route_params
         params.require(:route).permit(:name, :description, spots: %i[spot_type spot_id transport])
+      end
+
+      # 省略されたスカラー項目で既存値を nil 上書きしないよう、渡されたキーだけ取り出す。
+      def scalar_params
+        route_params.slice(:name, :description)
       end
 
       def spots_params

--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -5,6 +5,7 @@ class Route < ApplicationRecord
   accepts_nested_attributes_for :route_spots, allow_destroy: true
 
   validates :name, presence: true
+  validates :route_spots, presence: true
 
   def self.ransackable_attributes(_auth_object = nil)
     %w[name description]

--- a/app/models/route.rb
+++ b/app/models/route.rb
@@ -1,0 +1,16 @@
+class Route < ApplicationRecord
+  belongs_to :user
+  has_many :route_spots, -> { order(:position) }, dependent: :destroy, inverse_of: :route
+
+  accepts_nested_attributes_for :route_spots, allow_destroy: true
+
+  validates :name, presence: true
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[name description]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    %w[route_spots]
+  end
+end

--- a/app/models/route_spot.rb
+++ b/app/models/route_spot.rb
@@ -1,0 +1,23 @@
+class RouteSpot < ApplicationRecord
+  SPOT_TYPES = { 'greentea' => 'Greentea', 'temple' => 'Temple' }.freeze
+
+  belongs_to :route, inverse_of: :route_spots
+  belongs_to :spottable, polymorphic: true
+
+  # 移動手段（任意）: 次のスポットへの移動手段。未設定可。
+  enum transport: { walk: 0, train: 1, bus: 2, car: 3 }
+
+  validates :position, presence: true,
+                       numericality: { only_integer: true, greater_than: 0 }
+  validates :spottable_type, inclusion: { in: SPOT_TYPES.values }
+
+  # API で受け取る "greentea" / "temple" を ActiveRecord のクラス名に変換する。
+  def self.spottable_type_for(spot_type)
+    SPOT_TYPES[spot_type.to_s]
+  end
+
+  # ActiveRecord のクラス名を API の "greentea" / "temple" に戻す。
+  def spot_type
+    SPOT_TYPES.key(spottable_type)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
   accepts_nested_attributes_for :authentications
   has_many :greenteacomments, dependent: :destroy
   has_many :templecomments, dependent: :destroy
+  has_many :routes, dependent: :destroy
 
   validates :name, presence: true
 

--- a/app/serializers/api/v1/route_detail_serializer.rb
+++ b/app/serializers/api/v1/route_detail_serializer.rb
@@ -1,0 +1,49 @@
+module Api
+  module V1
+    class RouteDetailSerializer
+      include JSONAPI::Serializer
+
+      attributes :name, :description
+
+      attribute :created_at, &:created_at
+      attribute :updated_at, &:updated_at
+
+      attribute :spots do |obj|
+        ordered = obj.route_spots.to_a
+        ordered.each_with_index.map do |route_spot, index|
+          next_spot = ordered[index + 1]
+          RouteDetailSerializer.spot_payload(route_spot, next_spot)
+        end
+      end
+
+      # ルート内の 1 スポットを表す要素を組み立てる。
+      # distance_to_next_meters は次のスポットまでの距離（メートル・整数）。最後は nil。
+      def self.spot_payload(route_spot, next_spot)
+        spot = route_spot.spottable
+        {
+          position: route_spot.position,
+          spot_type: route_spot.spot_type,
+          transport: route_spot.transport,
+          id: spot.id,
+          name: spot.name,
+          address: spot.address,
+          access: spot.access,
+          latitude: spot.latitude,
+          longitude: spot.longitude,
+          img: spot.img,
+          distance_to_next_meters: distance_between(spot, next_spot&.spottable)
+        }
+      end
+
+      def self.distance_between(spot, next_spot)
+        return nil unless next_spot
+        return nil unless spot.latitude && spot.longitude
+        return nil unless next_spot.latitude && next_spot.longitude
+
+        origin = Geokit::LatLng.new(spot.latitude, spot.longitude)
+        target = Geokit::LatLng.new(next_spot.latitude, next_spot.longitude)
+        (origin.distance_to(target, units: :kms) * 1000).round
+      end
+    end
+  end
+end

--- a/app/serializers/api/v1/route_serializer.rb
+++ b/app/serializers/api/v1/route_serializer.rb
@@ -1,0 +1,16 @@
+module Api
+  module V1
+    class RouteSerializer
+      include JSONAPI::Serializer
+
+      attributes :name, :description
+
+      attribute :spot_count do |obj, params|
+        params[:spot_counts]&.fetch(obj.id, 0) || obj.route_spots.size
+      end
+
+      attribute :created_at, &:created_at
+      attribute :updated_at, &:updated_at
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
 
       get 'nearby', to: 'nearby#search'
 
+      resources :routes, only: %i[index show create update destroy]
+
       resources :greentea_likes, only: %i[index create destroy]
       resources :temple_likes, only: %i[index create destroy]
       resources :greenteacomments, only: %i[index create destroy]

--- a/db/migrate/20260611054810_create_routes.rb
+++ b/db/migrate/20260611054810_create_routes.rb
@@ -1,0 +1,11 @@
+class CreateRoutes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :routes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :name, null: false
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260611054820_create_route_spots.rb
+++ b/db/migrate/20260611054820_create_route_spots.rb
@@ -1,0 +1,14 @@
+class CreateRouteSpots < ActiveRecord::Migration[7.0]
+  def change
+    create_table :route_spots do |t|
+      t.references :route, null: false, foreign_key: true
+      t.references :spottable, polymorphic: true, null: false
+      t.integer :position, null: false
+      t.integer :transport
+
+      t.timestamps
+    end
+
+    add_index :route_spots, %i[route_id position]
+  end
+end

--- a/db/migrate/20260611054820_create_route_spots.rb
+++ b/db/migrate/20260611054820_create_route_spots.rb
@@ -9,6 +9,6 @@ class CreateRouteSpots < ActiveRecord::Migration[7.0]
       t.timestamps
     end
 
-    add_index :route_spots, %i[route_id position]
+    add_index :route_spots, %i[route_id position], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_06_03_040345) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_11_054820) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -95,6 +95,28 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_03_040345) do
     t.float "longitude"
   end
 
+  create_table "route_spots", force: :cascade do |t|
+    t.bigint "route_id", null: false
+    t.string "spottable_type", null: false
+    t.bigint "spottable_id", null: false
+    t.integer "position", null: false
+    t.integer "transport"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["route_id", "position"], name: "index_route_spots_on_route_id_and_position"
+    t.index ["route_id"], name: "index_route_spots_on_route_id"
+    t.index ["spottable_type", "spottable_id"], name: "index_route_spots_on_spottable"
+  end
+
+  create_table "routes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "name", null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_routes_on_user_id"
+  end
+
   create_table "temple_areas", force: :cascade do |t|
     t.bigint "temple_id", null: false
     t.bigint "area_id", null: false
@@ -153,6 +175,8 @@ ActiveRecord::Schema[7.0].define(version: 2026_06_03_040345) do
   add_foreign_key "greentea_likes", "users"
   add_foreign_key "greenteacomments", "greenteas"
   add_foreign_key "greenteacomments", "users"
+  add_foreign_key "route_spots", "routes"
+  add_foreign_key "routes", "users"
   add_foreign_key "temple_areas", "areas"
   add_foreign_key "temple_areas", "temples"
   add_foreign_key "temple_likes", "temples"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -103,7 +103,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_11_054820) do
     t.integer "transport"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["route_id", "position"], name: "index_route_spots_on_route_id_and_position"
+    t.index ["route_id", "position"], name: "index_route_spots_on_route_id_and_position", unique: true
     t.index ["route_id"], name: "index_route_spots_on_route_id"
     t.index ["spottable_type", "spottable_id"], name: "index_route_spots_on_spottable"
   end

--- a/spec/factories/route_spots.rb
+++ b/spec/factories/route_spots.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :route_spot do
+    association :route
+    association :spottable, factory: :greentea
+    sequence(:position) { |n| n }
+    transport { nil }
+  end
+end

--- a/spec/factories/routes.rb
+++ b/spec/factories/routes.rb
@@ -3,5 +3,10 @@ FactoryBot.define do
     association :user
     sequence(:name) { |n| "京都抹茶巡りルート#{n}" }
     description { '神社とお茶屋さんを巡るおすすめルート' }
+
+    # Route は最低 1 スポット必須なので、デフォルトで 1 件持たせて有効な状態にする。
+    after(:build) do |route|
+      route.route_spots << build(:route_spot, route: route, position: 1) if route.route_spots.empty?
+    end
   end
 end

--- a/spec/factories/routes.rb
+++ b/spec/factories/routes.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :route do
+    association :user
+    sequence(:name) { |n| "京都抹茶巡りルート#{n}" }
+    description { '神社とお茶屋さんを巡るおすすめルート' }
+  end
+end

--- a/spec/requests/api/v1/routes_spec.rb
+++ b/spec/requests/api/v1/routes_spec.rb
@@ -9,6 +9,15 @@ RSpec.describe 'Api::V1::Routes', type: :request do
   let(:greentea) { create(:greentea) }
   let(:temple) { create(:temple) }
 
+  # spots: [{ spottable:, transport: }] を順序付きで持つ Route を 1 件作る。
+  def create_route_for(owner, spots)
+    Route.create!(
+      user: owner,
+      name: 'テストルート',
+      route_spots: spots.each_with_index.map { |attrs, i| RouteSpot.new(position: i + 1, **attrs) }
+    )
+  end
+
   describe 'GET /api/v1/routes' do
     context 'when unauthenticated' do
       it 'returns 401' do
@@ -19,9 +28,8 @@ RSpec.describe 'Api::V1::Routes', type: :request do
 
     context 'when authenticated' do
       it 'returns only the current user\'s routes with meta and spot_count' do
-        mine = create(:route, user: user)
-        create(:route_spot, route: mine, spottable: greentea, position: 1)
-        create(:route, user: other_user)
+        mine = create_route_for(user, [{ spottable: greentea }])
+        create_route_for(other_user, [{ spottable: greentea }])
 
         get '/api/v1/routes', headers: auth
 
@@ -42,15 +50,14 @@ RSpec.describe 'Api::V1::Routes', type: :request do
 
   describe 'GET /api/v1/routes/:id' do
     it 'returns 401 when unauthenticated' do
-      route = create(:route, user: user)
+      route = create_route_for(user, [{ spottable: greentea }])
       get "/api/v1/routes/#{route.id}"
       expect(response).to have_http_status(:unauthorized)
     end
 
     it 'returns the route with ordered spots and distance_to_next_meters' do
-      route = create(:route, user: user)
-      create(:route_spot, route: route, spottable: temple, position: 1, transport: :walk)
-      create(:route_spot, route: route, spottable: greentea, position: 2)
+      spots = [{ spottable: temple, transport: :walk }, { spottable: greentea }]
+      route = create_route_for(user, spots)
 
       get "/api/v1/routes/#{route.id}", headers: auth
 
@@ -65,7 +72,7 @@ RSpec.describe 'Api::V1::Routes', type: :request do
     end
 
     it 'returns 404 for another user\'s route' do
-      route = create(:route, user: other_user)
+      route = create_route_for(other_user, [{ spottable: greentea }])
       get "/api/v1/routes/#{route.id}", headers: auth
       expect(response).to have_http_status(:not_found)
     end
@@ -104,11 +111,39 @@ RSpec.describe 'Api::V1::Routes', type: :request do
       expect(Route.last.user).to eq(user)
     end
 
+    it 'allows duplicate spots in the same route' do
+      params = valid_params.deep_dup
+      params[:route][:spots] = [
+        { spot_type: 'greentea', spot_id: greentea.id },
+        { spot_type: 'greentea', spot_id: greentea.id }
+      ]
+      expect {
+        post '/api/v1/routes', params: params, headers: auth
+      }.to change(RouteSpot, :count).by(2)
+      expect(response).to have_http_status(:created)
+    end
+
     it 'returns 422 when name is missing' do
       params = valid_params.deep_dup
       params[:route][:name] = ''
       expect {
         post '/api/v1/routes', params: params, headers: auth
+      }.not_to change(Route, :count)
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'returns 422 when spots are empty' do
+      params = valid_params.deep_dup
+      params[:route][:spots] = []
+      expect {
+        post '/api/v1/routes', params: params, headers: auth
+      }.not_to change(Route, :count)
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'returns 422 when the spots key is absent' do
+      expect {
+        post '/api/v1/routes', params: { route: { name: 'スポットなし' } }, headers: auth
       }.not_to change(Route, :count)
       expect(response).to have_http_status(:unprocessable_entity)
     end
@@ -143,8 +178,7 @@ RSpec.describe 'Api::V1::Routes', type: :request do
 
   describe 'PATCH /api/v1/routes/:id' do
     it 'replaces the route name and spots' do
-      route = create(:route, user: user, name: '旧ルート')
-      create(:route_spot, route: route, spottable: greentea, position: 1)
+      route = create_route_for(user, [{ spottable: greentea }])
 
       patch "/api/v1/routes/#{route.id}",
             params: {
@@ -162,8 +196,33 @@ RSpec.describe 'Api::V1::Routes', type: :request do
       expect(route.route_spots.first.transport).to eq('train')
     end
 
+    it 'updates only scalar fields and preserves spots when the spots key is omitted' do
+      route = create_route_for(user, [{ spottable: greentea }, { spottable: temple }])
+
+      patch "/api/v1/routes/#{route.id}",
+            params: { route: { description: '説明だけ更新' } },
+            headers: auth
+
+      expect(response).to have_http_status(:ok)
+      route.reload
+      expect(route.description).to eq('説明だけ更新')
+      expect(route.name).to eq('テストルート')
+      expect(route.route_spots.count).to eq(2)
+    end
+
+    it 'returns 422 and keeps existing spots when updating to empty spots' do
+      route = create_route_for(user, [{ spottable: greentea }])
+
+      patch "/api/v1/routes/#{route.id}",
+            params: { route: { name: 'x', spots: [] } },
+            headers: auth
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(route.reload.route_spots.count).to eq(1)
+    end
+
     it 'returns 404 for another user\'s route' do
-      route = create(:route, user: other_user)
+      route = create_route_for(other_user, [{ spottable: greentea }])
       patch "/api/v1/routes/#{route.id}", params: { route: { name: 'x' } }, headers: auth
       expect(response).to have_http_status(:not_found)
     end
@@ -171,14 +230,13 @@ RSpec.describe 'Api::V1::Routes', type: :request do
 
   describe 'DELETE /api/v1/routes/:id' do
     it 'returns 401 when unauthenticated' do
-      route = create(:route, user: user)
+      route = create_route_for(user, [{ spottable: greentea }])
       delete "/api/v1/routes/#{route.id}"
       expect(response).to have_http_status(:unauthorized)
     end
 
     it 'deletes the current user\'s route and its spots' do
-      route = create(:route, user: user)
-      create(:route_spot, route: route, spottable: greentea, position: 1)
+      route = create_route_for(user, [{ spottable: greentea }])
 
       expect {
         delete "/api/v1/routes/#{route.id}", headers: auth
@@ -188,7 +246,7 @@ RSpec.describe 'Api::V1::Routes', type: :request do
     end
 
     it 'returns 404 for another user\'s route' do
-      route = create(:route, user: other_user)
+      route = create_route_for(other_user, [{ spottable: greentea }])
       expect {
         delete "/api/v1/routes/#{route.id}", headers: auth
       }.not_to change(Route, :count)

--- a/spec/requests/api/v1/routes_spec.rb
+++ b/spec/requests/api/v1/routes_spec.rb
@@ -1,0 +1,198 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Routes', type: :request do
+  let(:user) { User.create!(name: 'ルート作成ユーザー') }
+  let(:other_user) { User.create!(name: '他人') }
+  let(:token) { JwtService.encode({ user_id: user.id }) }
+  let(:auth) { { 'Authorization' => "Bearer #{token}" } }
+
+  let(:greentea) { create(:greentea) }
+  let(:temple) { create(:temple) }
+
+  describe 'GET /api/v1/routes' do
+    context 'when unauthenticated' do
+      it 'returns 401' do
+        get '/api/v1/routes'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated' do
+      it 'returns only the current user\'s routes with meta and spot_count' do
+        mine = create(:route, user: user)
+        create(:route_spot, route: mine, spottable: greentea, position: 1)
+        create(:route, user: other_user)
+
+        get '/api/v1/routes', headers: auth
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        ids = json['data'].map { |d| d['id'] }
+        expect(ids).to eq([mine.id])
+        expect(json['data'].first['spot_count']).to eq(1)
+        expect(json['meta']).to include(
+          'current_page' => 1,
+          'total_pages' => 1,
+          'total_count' => 1,
+          'per_page' => 15
+        )
+      end
+    end
+  end
+
+  describe 'GET /api/v1/routes/:id' do
+    it 'returns 401 when unauthenticated' do
+      route = create(:route, user: user)
+      get "/api/v1/routes/#{route.id}"
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'returns the route with ordered spots and distance_to_next_meters' do
+      route = create(:route, user: user)
+      create(:route_spot, route: route, spottable: temple, position: 1, transport: :walk)
+      create(:route_spot, route: route, spottable: greentea, position: 2)
+
+      get "/api/v1/routes/#{route.id}", headers: auth
+
+      expect(response).to have_http_status(:ok)
+      spots = response.parsed_body['data']['spots']
+      expect(spots.map { |s| s['position'] }).to eq([1, 2])
+      expect(spots.map { |s| s['spot_type'] }).to eq(%w[temple greentea])
+      expect(spots.first['transport']).to eq('walk')
+      expect(spots.first['name']).to eq(temple.name)
+      expect(spots.first['distance_to_next_meters']).to be_a(Integer)
+      expect(spots.last['distance_to_next_meters']).to be_nil
+    end
+
+    it 'returns 404 for another user\'s route' do
+      route = create(:route, user: other_user)
+      get "/api/v1/routes/#{route.id}", headers: auth
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'POST /api/v1/routes' do
+    let(:valid_params) do
+      {
+        route: {
+          name: '祇園抹茶巡り',
+          description: '神社とお茶屋さんを巡る',
+          spots: [
+            { spot_type: 'temple', spot_id: temple.id, transport: 'walk' },
+            { spot_type: 'greentea', spot_id: greentea.id }
+          ]
+        }
+      }
+    end
+
+    it 'returns 401 when unauthenticated' do
+      post '/api/v1/routes', params: valid_params
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'creates a route with ordered spots and returns 201' do
+      expect {
+        post '/api/v1/routes', params: valid_params, headers: auth
+      }.to change(Route, :count).by(1).and change(RouteSpot, :count).by(2)
+
+      expect(response).to have_http_status(:created)
+      data = response.parsed_body['data']
+      expect(data['name']).to eq('祇園抹茶巡り')
+      expect(data['spots'].map { |s| s['position'] }).to eq([1, 2])
+      expect(data['spots'].first['spot_type']).to eq('temple')
+
+      expect(Route.last.user).to eq(user)
+    end
+
+    it 'returns 422 when name is missing' do
+      params = valid_params.deep_dup
+      params[:route][:name] = ''
+      expect {
+        post '/api/v1/routes', params: params, headers: auth
+      }.not_to change(Route, :count)
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'returns 422 for an invalid spot_type' do
+      params = valid_params.deep_dup
+      params[:route][:spots] = [{ spot_type: 'castle', spot_id: 1 }]
+      expect {
+        post '/api/v1/routes', params: params, headers: auth
+      }.not_to change(Route, :count)
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'returns 422 for a non-existent spot' do
+      params = valid_params.deep_dup
+      params[:route][:spots] = [{ spot_type: 'greentea', spot_id: 999_999 }]
+      expect {
+        post '/api/v1/routes', params: params, headers: auth
+      }.not_to change(Route, :count)
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it 'returns 422 for an invalid transport' do
+      params = valid_params.deep_dup
+      params[:route][:spots] = [{ spot_type: 'greentea', spot_id: greentea.id, transport: 'teleport' }]
+      expect {
+        post '/api/v1/routes', params: params, headers: auth
+      }.not_to change(Route, :count)
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe 'PATCH /api/v1/routes/:id' do
+    it 'replaces the route name and spots' do
+      route = create(:route, user: user, name: '旧ルート')
+      create(:route_spot, route: route, spottable: greentea, position: 1)
+
+      patch "/api/v1/routes/#{route.id}",
+            params: {
+              route: {
+                name: '新ルート',
+                spots: [{ spot_type: 'temple', spot_id: temple.id, transport: 'train' }]
+              }
+            },
+            headers: auth
+
+      expect(response).to have_http_status(:ok)
+      route.reload
+      expect(route.name).to eq('新ルート')
+      expect(route.route_spots.map(&:spottable)).to eq([temple])
+      expect(route.route_spots.first.transport).to eq('train')
+    end
+
+    it 'returns 404 for another user\'s route' do
+      route = create(:route, user: other_user)
+      patch "/api/v1/routes/#{route.id}", params: { route: { name: 'x' } }, headers: auth
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe 'DELETE /api/v1/routes/:id' do
+    it 'returns 401 when unauthenticated' do
+      route = create(:route, user: user)
+      delete "/api/v1/routes/#{route.id}"
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'deletes the current user\'s route and its spots' do
+      route = create(:route, user: user)
+      create(:route_spot, route: route, spottable: greentea, position: 1)
+
+      expect {
+        delete "/api/v1/routes/#{route.id}", headers: auth
+      }.to change(Route, :count).by(-1).and change(RouteSpot, :count).by(-1)
+
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it 'returns 404 for another user\'s route' do
+      route = create(:route, user: other_user)
+      expect {
+        delete "/api/v1/routes/#{route.id}", headers: auth
+      }.not_to change(Route, :count)
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/requests/api/v1/routes_spec.rb
+++ b/spec/requests/api/v1/routes_spec.rb
@@ -20,9 +20,11 @@ RSpec.describe 'Api::V1::Routes', type: :request do
 
   describe 'GET /api/v1/routes' do
     context 'when unauthenticated' do
-      it 'returns 401' do
+      it 'returns 401 with a JSON error body' do
         get '/api/v1/routes'
         expect(response).to have_http_status(:unauthorized)
+        expect(response.media_type).to eq('application/json')
+        expect(response.parsed_body['error']).to be_present
       end
     end
 
@@ -130,6 +132,8 @@ RSpec.describe 'Api::V1::Routes', type: :request do
         post '/api/v1/routes', params: params, headers: auth
       }.not_to change(Route, :count)
       expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.media_type).to eq('application/json')
+      expect(response.parsed_body['error']).to be_present
     end
 
     it 'returns 422 when spots are empty' do
@@ -177,6 +181,12 @@ RSpec.describe 'Api::V1::Routes', type: :request do
   end
 
   describe 'PATCH /api/v1/routes/:id' do
+    it 'returns 401 when unauthenticated' do
+      route = create_route_for(user, [{ spottable: greentea }])
+      patch "/api/v1/routes/#{route.id}", params: { route: { name: 'x' } }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
     it 'replaces the route name and spots' do
       route = create_route_for(user, [{ spottable: greentea }])
 


### PR DESCRIPTION
## 概要

ユーザーが**神社(temple)と抹茶スイーツ店(greentea)を複数選び、順番に並べた自分専用ルート**を作成・編集・削除できる API を `api/v1` に追加します。

移動手段(`transport`)は **任意項目** として持たせ、今回は「選べる」ところまで。スポット間の経路探索・所要時間計算は将来の別 issue で対応する想定です。

> 実装範囲は **API のみ**（Next.js フロント [matcha-to-jinja](https://github.com/hiiragi17/matcha-to-jinja) 向け）。既存 Web 画面(#136 で撤去予定)には手を入れていません。

## データモデル

| テーブル | 内容 |
|---|---|
| `routes` | `user_id`, `name`, `description` |
| `route_spots` | `route_id`, `spottable`(polymorphic), `position`, `transport` |

- `route_spots` は **polymorphic(`spottable`)** で temple / greentea を 1 つのルートに混在保持
- `position` でルート内の順序を表現
- `transport` は enum(`walk` / `train` / `bus` / `car`)で **nullable**（未設定可）
- `User has_many :routes, dependent: :destroy`

## エンドポイント

すべて **JWT 認証必須**。`current_user` 自身のルートのみ参照・操作可（他人のルートは 404）。

```text
GET    /api/v1/routes        # 自分のルート一覧（spot_count + meta）
POST   /api/v1/routes        # 作成（spots をネストで受け取り、配列順 = ルート順）
GET    /api/v1/routes/:id     # 詳細（spots を順序展開 + distance_to_next_meters）
PATCH  /api/v1/routes/:id     # name/description と spots を総入れ替え
DELETE /api/v1/routes/:id
```

リクエスト例:

```json
{ "route": { "name": "祇園抹茶巡り", "description": "...", "spots": [
  { "spot_type": "temple",   "spot_id": 12, "transport": "walk" },
  { "spot_type": "greentea", "spot_id": 5 }
]}}
```

- `spot_type` は `"temple"` / `"greentea"`、`spot_id` は対象スポットの id
- `position` は配列の並び順から自動採番（先頭=1）
- 不正な `spot_type` / 存在しない `spot_id` / 不正な `transport` / `name` 空 はいずれも 422

## レスポンス

- 一覧: 既存 API と同じく `{ data: [...], meta: { current_page, total_pages, total_count, per_page } }`
- 詳細: `spots` を順序通りに展開。各スポットに既存の距離規約に合わせて `distance_to_next_meters`（次スポットまでの距離・**整数メートル**、最後は `null`）を付与

## 実装方針

- 既存パターンを踏襲（`Api::V1::BaseController` の JWT 認証 / `jsonapi-serializer` / N+1 回避のための一括集計）
- Ransack の `ransackable_attributes` / `ransackable_associations` は allowlist で明示

## テスト

- request spec を新規追加（一覧 / 詳細 / 作成 / 更新 / 削除、認証・権限・バリデーション込みで 16 例）
- `bundle exec rspec spec/requests` … **125 例 green（回帰なし）**
- 新規ファイルは **RuboCop クリーン**

## 補足

- 本ブランチ稼働環境は既に **Rails 7.1.6**（#124 着地済み）でした。そのため `db/schema.rb` のバージョン印が `[7.0] → [7.1]` に更新されています（マイグレーション再生成による正しい反映）。

Closes #65


---
_Generated by [Claude Code](https://claude.ai/code/session_01QLNcxdiAmzBAFRdZGCpUAH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Route management API: Create, list, view, update, and delete user routes
  * Add multiple stops to routes with transport methods (walk, train, bus, car)
  * View route details including ordered stops with distance metrics between consecutive locations
  * Authentication and authorization for all route operations
  * Comprehensive validation and error handling for route and stop data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->