### PR TITLE
feat: モデルルートの経路・所要時間計算を追加 (#153)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@
 外部 API:
 - Google Geocoding API（住所→緯度経度）
 - Google Maps JavaScript API（地図描画）
+- Google Directions API（モデルルートの経路・所要時間計算。#153）
 
 ## セットアップ / よく使うコマンド
 
@@ -42,7 +43,8 @@ bundle exec rubocop
 | 変数名 | 用途 |
 |---|---|
 | `GOOGLE_GEOCODING_API_KEY` | 住所 → 緯度経度（Geocoder） |
-| `GOOGLE_MAPS_API_KEY` | 地図描画（JS から参照） |
+| `GOOGLE_MAPS_API_KEY` | 地図描画（JS から参照）。`GOOGLE_DIRECTIONS_API_KEY` 未設定時は経路計算でも再利用 |
+| `GOOGLE_DIRECTIONS_API_KEY` | モデルルートの経路・所要時間計算（Directions API・#153）。未設定なら `GOOGLE_MAPS_API_KEY` にフォールバック |
 | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Google OAuth（#90 で Twitter から移行） |
 | `LINE_KEY` / `LINE_SECRET` | LINE OAuth |
 | `DATABASE_URL` | 本番 PostgreSQL（#118 で Neon へ移行予定） |

--- a/app/controllers/api/v1/routes_controller.rb
+++ b/app/controllers/api/v1/routes_controller.rb
@@ -31,6 +31,7 @@ module Api
           route.save!
         end
 
+        compute_and_store_legs(route)
         render_route_detail(route, status: :created)
       rescue ActiveRecord::RecordInvalid => e
         render_unprocessable(e.record.errors.full_messages)
@@ -40,6 +41,7 @@ module Api
 
       def update
         route = current_user.routes.find(params[:id])
+        spots_changed = false
 
         ActiveRecord::Base.transaction do
           route.assign_attributes(scalar_params)
@@ -48,10 +50,12 @@ module Api
           if route_params.key?(:spots)
             route.route_spots.destroy_all
             build_spots(route, spots_params)
+            spots_changed = true
           end
           route.save!
         end
 
+        compute_and_store_legs(route) if spots_changed
         render_route_detail(route.reload)
       rescue ActiveRecord::RecordInvalid => e
         render_unprocessable(e.record.errors.full_messages)
@@ -102,6 +106,22 @@ module Api
         return value.to_s if RouteSpot.transports.key?(value.to_s)
 
         raise InvalidSpotError, "invalid transport: #{value}"
+      end
+
+      # 隣接スポット間の経路距離・所要時間を Directions API で求めて保存する。
+      # 外部 API 呼び出しのため DB トランザクション外で実行し、失敗した leg は
+      # nil のまま（serializer 側で直線距離フォールバック）。
+      def compute_and_store_legs(route)
+        spots = route.route_spots.reload.to_a
+        spots.each_cons(2) do |from, to|
+          leg = DirectionsService.leg(origin: from.spottable, destination: to.spottable, mode: from.transport)
+          next unless leg
+
+          from.update!(
+            leg_distance_meters: leg[:distance_meters],
+            leg_duration_seconds: leg[:duration_seconds]
+          )
+        end
       end
 
       def render_route_detail(route, status: :ok)

--- a/app/controllers/api/v1/routes_controller.rb
+++ b/app/controllers/api/v1/routes_controller.rb
@@ -111,13 +111,18 @@ module Api
       # 隣接スポット間の経路距離・所要時間を Directions API で求めて保存する。
       # 外部 API 呼び出しのため DB トランザクション外で実行し、失敗した leg は
       # nil のまま（serializer 側で直線距離フォールバック）。
+      #
+      # build_spots でスポットは spottable 付きでメモリ上にロード済みなので、
+      # reload せずに position 順へ並べ替えて使う（spottable の N+1 を避ける）。
       def compute_and_store_legs(route)
-        spots = route.route_spots.reload.to_a
+        spots = route.route_spots.to_a.sort_by(&:position)
         spots.each_cons(2) do |from, to|
           leg = DirectionsService.leg(origin: from.spottable, destination: to.spottable, mode: from.transport)
           next unless leg
 
-          from.update!(
+          # best-effort（コミット後・トランザクション外）なので bang は使わない。
+          # 失敗しても 500 にせず、その leg は nil のまま（直線距離フォールバック）。
+          from.update(
             leg_distance_meters: leg[:distance_meters],
             leg_duration_seconds: leg[:duration_seconds]
           )

--- a/app/serializers/api/v1/route_detail_serializer.rb
+++ b/app/serializers/api/v1/route_detail_serializer.rb
@@ -9,7 +9,7 @@ module Api
       attribute :updated_at, &:updated_at
 
       attribute :spots do |obj|
-        ordered = obj.route_spots.to_a
+        ordered = RouteDetailSerializer.ordered_spots(obj)
         ordered.each_with_index.map do |route_spot, index|
           next_spot = ordered[index + 1]
           RouteDetailSerializer.spot_payload(route_spot, next_spot)
@@ -19,12 +19,18 @@ module Api
       # ルート全体の経路距離合計（メートル・整数）。
       # 各 leg は経路距離（leg_distance_meters）優先、無ければ直線距離でフォールバック。
       attribute :total_distance_meters do |obj|
-        RouteDetailSerializer.total_distance_meters(obj.route_spots.to_a)
+        RouteDetailSerializer.total_distance_meters(RouteDetailSerializer.ordered_spots(obj))
       end
 
       # ルート全体の所要時間合計（秒・整数）。算出済みの leg が 1 つも無ければ nil。
       attribute :total_duration_seconds do |obj|
-        RouteDetailSerializer.total_duration_seconds(obj.route_spots.to_a)
+        RouteDetailSerializer.total_duration_seconds(RouteDetailSerializer.ordered_spots(obj))
+      end
+
+      # route_spots を position 順で取得する。association scope（order(:position)）でも
+      # 担保されるが、DB ロード順に依存しないよう明示的に並べ替える（controller と統一）。
+      def self.ordered_spots(route)
+        route.route_spots.to_a.sort_by(&:position)
       end
 
       # ルート内の 1 スポットを表す要素を組み立てる。

--- a/app/serializers/api/v1/route_detail_serializer.rb
+++ b/app/serializers/api/v1/route_detail_serializer.rb
@@ -16,8 +16,21 @@ module Api
         end
       end
 
+      # ルート全体の経路距離合計（メートル・整数）。
+      # 各 leg は経路距離（leg_distance_meters）優先、無ければ直線距離でフォールバック。
+      attribute :total_distance_meters do |obj|
+        RouteDetailSerializer.total_distance_meters(obj.route_spots.to_a)
+      end
+
+      # ルート全体の所要時間合計（秒・整数）。算出済みの leg が 1 つも無ければ nil。
+      attribute :total_duration_seconds do |obj|
+        RouteDetailSerializer.total_duration_seconds(obj.route_spots.to_a)
+      end
+
       # ルート内の 1 スポットを表す要素を組み立てる。
-      # distance_to_next_meters は次のスポットまでの距離（メートル・整数）。最後は nil。
+      # - distance_to_next_meters: 次スポットまでの直線距離（メートル・整数）。最後は nil。
+      # - route_distance_to_next_meters: 次スポットまでの経路距離（Directions API）。未算出は nil。
+      # - duration_to_next_seconds: 次スポットまでの所要時間（秒）。未算出は nil。
       def self.spot_payload(route_spot, next_spot)
         spot = route_spot.spottable
         {
@@ -31,8 +44,25 @@ module Api
           latitude: spot.latitude,
           longitude: spot.longitude,
           img: spot.img,
-          distance_to_next_meters: distance_between(spot, next_spot&.spottable)
+          distance_to_next_meters: distance_between(spot, next_spot&.spottable),
+          route_distance_to_next_meters: next_spot ? route_spot.leg_distance_meters : nil,
+          duration_to_next_seconds: next_spot ? route_spot.leg_duration_seconds : nil
         }
+      end
+
+      def self.total_distance_meters(ordered)
+        return 0 if ordered.size < 2
+
+        ordered.each_cons(2).sum do |from, to|
+          from.leg_distance_meters || distance_between(from.spottable, to.spottable) || 0
+        end
+      end
+
+      def self.total_duration_seconds(ordered)
+        durations = ordered.each_cons(2).map { |from, _to| from.leg_duration_seconds }.compact
+        return nil if durations.empty?
+
+        durations.sum
       end
 
       def self.distance_between(spot, next_spot)

--- a/app/serializers/api/v1/route_detail_serializer.rb
+++ b/app/serializers/api/v1/route_detail_serializer.rb
@@ -58,6 +58,9 @@ module Api
         end
       end
 
+      # 所要時間には直線距離のようなフォールバックが無いため、算出済みの leg のみを
+      # 合算する（一部 leg のみ算出済みなら部分合計）。1 つも無ければ nil。
+      # ＝ total_distance_meters（常に整数）とは非対称だが意図的な契約。
       def self.total_duration_seconds(ordered)
         durations = ordered.each_cons(2).map { |from, _to| from.leg_duration_seconds }.compact
         return nil if durations.empty?

--- a/app/services/directions_service.rb
+++ b/app/services/directions_service.rb
@@ -1,0 +1,91 @@
+require 'net/http'
+require 'json'
+
+# Google Directions API を叩いて、2 スポット間の「経路距離・所要時間」を求める。
+#
+# 失敗時（API キー未設定 / 座標欠落 / API エラー / タイムアウト）は nil を返す。
+# 呼び出し側は nil を受けたら直線距離フォールバックに任せ、ルート取得自体は
+# 失敗させない方針（#153）。
+class DirectionsService
+  ENDPOINT = 'https://maps.googleapis.com/maps/api/directions/json'.freeze
+  OPEN_TIMEOUT = 5
+  READ_TIMEOUT = 5
+
+  # route_spots.transport(enum) → Google Directions の mode / transit_mode。
+  TRANSPORT_MODES = {
+    'walk' => { mode: 'walking' },
+    'car' => { mode: 'driving' },
+    'train' => { mode: 'transit', transit_mode: 'rail' },
+    'bus' => { mode: 'transit', transit_mode: 'bus' }
+  }.freeze
+  # transport 未設定（nil）や未知の値は徒歩扱い。
+  DEFAULT_MODE = { mode: 'walking' }.freeze
+
+  class << self
+    # origin / destination は latitude / longitude を持つオブジェクト（Greentea / Temple）。
+    # mode は route_spots.transport の文字列（"walk" / "train" など、nil 可）。
+    # 返り値: { distance_meters: Integer, duration_seconds: Integer } または nil。
+    def leg(origin:, destination:, mode: nil)
+      return nil if api_key.blank?
+      return nil unless coordinates?(origin) && coordinates?(destination)
+
+      body = request(build_url(origin, destination, mode))
+      return nil unless body
+
+      parse(body)
+    end
+
+    private
+
+    def api_key
+      ENV['GOOGLE_DIRECTIONS_API_KEY'].presence || ENV['GOOGLE_MAPS_API_KEY'].presence
+    end
+
+    def coordinates?(spot)
+      spot.respond_to?(:latitude) && spot.latitude.present? &&
+        spot.respond_to?(:longitude) && spot.longitude.present?
+    end
+
+    def mode_params(transport)
+      TRANSPORT_MODES.fetch(transport.to_s, DEFAULT_MODE)
+    end
+
+    def build_url(origin, destination, transport)
+      params = {
+        origin: "#{origin.latitude},#{origin.longitude}",
+        destination: "#{destination.latitude},#{destination.longitude}",
+        key: api_key
+      }.merge(mode_params(transport))
+
+      uri = URI(ENDPOINT)
+      uri.query = URI.encode_www_form(params)
+      uri
+    end
+
+    def request(uri)
+      response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true,
+                                                         open_timeout: OPEN_TIMEOUT, read_timeout: READ_TIMEOUT) do |http|
+        http.request(Net::HTTP::Get.new(uri))
+      end
+      return nil unless response.code.to_i == 200
+
+      JSON.parse(response.body)
+    rescue ::JSON::ParserError, ::Net::OpenTimeout, ::Net::ReadTimeout, ::SocketError, ::OpenSSL::SSL::SSLError => e
+      Rails.logger.info("DirectionsService request failed: #{e.class} #{e.message}")
+      nil
+    end
+
+    def parse(body)
+      return nil unless body['status'] == 'OK'
+
+      leg = body.dig('routes', 0, 'legs', 0)
+      return nil unless leg
+
+      distance = leg.dig('distance', 'value')
+      duration = leg.dig('duration', 'value')
+      return nil unless distance && duration
+
+      { distance_meters: distance.to_i, duration_seconds: duration.to_i }
+    end
+  end
+end

--- a/app/services/directions_service.rb
+++ b/app/services/directions_service.rb
@@ -70,7 +70,11 @@ class DirectionsService
       return nil unless response.code.to_i == 200
 
       JSON.parse(response.body)
-    rescue ::JSON::ParserError, ::Net::OpenTimeout, ::Net::ReadTimeout, ::SocketError, ::OpenSSL::SSL::SSLError => e
+    rescue ::JSON::ParserError, ::Net::ProtocolError, ::SocketError, ::SystemCallError,
+           ::IOError, ::Timeout::Error, ::OpenSSL::SSL::SSLError => e
+      # ベストエフォート: 接続リセット/拒否(Errno::*)・タイムアウト・EOF などの
+      # 一時的なネットワーク失敗は握りつぶし、呼び出し側で直線距離フォールバックに任せる。
+      # （ルート作成・更新はコミット済みのため、ここで例外を伝播させて 500 にしない）
       Rails.logger.info("DirectionsService request failed: #{e.class} #{e.message}")
       nil
     end

--- a/app/services/directions_service.rb
+++ b/app/services/directions_service.rb
@@ -26,10 +26,11 @@ class DirectionsService
     # mode は route_spots.transport の文字列（"walk" / "train" など、nil 可）。
     # 返り値: { distance_meters: Integer, duration_seconds: Integer } または nil。
     def leg(origin:, destination:, mode: nil)
-      return nil if api_key.blank?
+      key = api_key
+      return nil if key.blank?
       return nil unless coordinates?(origin) && coordinates?(destination)
 
-      body = request(build_url(origin, destination, mode))
+      body = request(build_url(origin, destination, mode, key))
       return nil unless body
 
       parse(body)
@@ -50,11 +51,11 @@ class DirectionsService
       TRANSPORT_MODES.fetch(transport.to_s, DEFAULT_MODE)
     end
 
-    def build_url(origin, destination, transport)
+    def build_url(origin, destination, transport, key)
       params = {
         origin: "#{origin.latitude},#{origin.longitude}",
         destination: "#{destination.latitude},#{destination.longitude}",
-        key: api_key
+        key: key
       }.merge(mode_params(transport))
 
       uri = URI(ENDPOINT)
@@ -75,7 +76,7 @@ class DirectionsService
       # ベストエフォート: 接続リセット/拒否(Errno::*)・タイムアウト・EOF などの
       # 一時的なネットワーク失敗は握りつぶし、呼び出し側で直線距離フォールバックに任せる。
       # （ルート作成・更新はコミット済みのため、ここで例外を伝播させて 500 にしない）
-      Rails.logger.info("DirectionsService request failed: #{e.class} #{e.message}")
+      Rails.logger.warn("DirectionsService request failed: #{e.class} #{e.message}")
       nil
     end
 

--- a/db/migrate/20260611063800_add_leg_metrics_to_route_spots.rb
+++ b/db/migrate/20260611063800_add_leg_metrics_to_route_spots.rb
@@ -1,0 +1,10 @@
+class AddLegMetricsToRouteSpots < ActiveRecord::Migration[7.0]
+  def change
+    # 次のスポットまでの経路距離・所要時間（Directions API の算出結果）。
+    # 最後のスポットや算出失敗時は null。
+    change_table :route_spots, bulk: true do |t|
+      t.integer :leg_distance_meters
+      t.integer :leg_duration_seconds
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_11_054820) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_11_063800) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -103,6 +103,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_06_11_054820) do
     t.integer "transport"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "leg_distance_meters"
+    t.integer "leg_duration_seconds"
     t.index ["route_id", "position"], name: "index_route_spots_on_route_id_and_position", unique: true
     t.index ["route_id"], name: "index_route_spots_on_route_id"
     t.index ["spottable_type", "spottable_id"], name: "index_route_spots_on_spottable"

--- a/spec/requests/api/v1/routes_spec.rb
+++ b/spec/requests/api/v1/routes_spec.rb
@@ -261,6 +261,29 @@ RSpec.describe 'Api::V1::Routes', type: :request do
       expect(route.route_spots.first.transport).to eq('train')
     end
 
+    it 'recomputes and stores leg metrics when spots change' do
+      route = create_route_for(user, [{ spottable: greentea }])
+      allow(DirectionsService).to receive(:leg)
+        .and_return({ distance_meters: 2000, duration_seconds: 1500 })
+
+      patch "/api/v1/routes/#{route.id}",
+            params: {
+              route: {
+                spots: [
+                  { spot_type: 'temple', spot_id: temple.id, transport: 'train' },
+                  { spot_type: 'greentea', spot_id: greentea.id }
+                ]
+              }
+            },
+            headers: auth
+
+      expect(response).to have_http_status(:ok)
+      first_spot = route.reload.route_spots.order(:position).first
+      expect(first_spot.leg_distance_meters).to eq(2000)
+      expect(first_spot.leg_duration_seconds).to eq(1500)
+      expect(response.parsed_body['data']['total_distance_meters']).to eq(2000)
+    end
+
     it 'updates only scalar fields and preserves spots when the spots key is omitted' do
       route = create_route_for(user, [{ spottable: greentea }, { spottable: temple }])
 

--- a/spec/requests/api/v1/routes_spec.rb
+++ b/spec/requests/api/v1/routes_spec.rb
@@ -149,7 +149,8 @@ RSpec.describe 'Api::V1::Routes', type: :request do
     end
 
     it 'computes and stores leg metrics via DirectionsService' do
-      allow(DirectionsService).to receive(:leg)
+      expect(DirectionsService).to receive(:leg)
+        .with(origin: temple, destination: greentea, mode: 'walk')
         .and_return({ distance_meters: 1500, duration_seconds: 1080 })
 
       post '/api/v1/routes', params: valid_params, headers: auth
@@ -165,6 +166,40 @@ RSpec.describe 'Api::V1::Routes', type: :request do
       data = response.parsed_body['data']
       expect(data['spots'].first['route_distance_to_next_meters']).to eq(1500)
       expect(data['total_distance_meters']).to eq(1500)
+      expect(data['total_duration_seconds']).to eq(1080)
+    end
+
+    it 'uses computed metrics for successful legs and falls back for failed ones' do
+      third = create(:greentea)
+      # leg1 は成功、leg2 は失敗（nil）。
+      allow(DirectionsService).to receive(:leg)
+        .and_return({ distance_meters: 1500, duration_seconds: 1080 }, nil)
+
+      post '/api/v1/routes',
+           params: {
+             route: {
+               name: '混在ルート',
+               spots: [
+                 { spot_type: 'temple', spot_id: temple.id, transport: 'walk' },
+                 { spot_type: 'greentea', spot_id: greentea.id, transport: 'train' },
+                 { spot_type: 'greentea', spot_id: third.id }
+               ]
+             }
+           },
+           headers: auth
+
+      expect(response).to have_http_status(:created)
+      data = response.parsed_body['data']
+      spots = data['spots']
+
+      # leg1: 経路距離・所要時間が入る
+      expect(spots[0]['route_distance_to_next_meters']).to eq(1500)
+      expect(spots[0]['duration_to_next_seconds']).to eq(1080)
+      # leg2: 失敗 → 経路値は nil、直線距離フォールバック
+      expect(spots[1]['route_distance_to_next_meters']).to be_nil
+      expect(spots[1]['distance_to_next_meters']).to be_a(Integer)
+      # 合計: 距離は leg1 経路 + leg2 直線、所要時間は算出済みの leg1 のみ
+      expect(data['total_distance_meters']).to eq(1500 + spots[1]['distance_to_next_meters'])
       expect(data['total_duration_seconds']).to eq(1080)
     end
 
@@ -286,6 +321,8 @@ RSpec.describe 'Api::V1::Routes', type: :request do
 
     it 'updates only scalar fields and preserves spots when the spots key is omitted' do
       route = create_route_for(user, [{ spottable: greentea }, { spottable: temple }])
+      # spots 未変更なので leg 再計算（外部 API 呼び出し）は走らない。
+      expect(DirectionsService).not_to receive(:leg)
 
       patch "/api/v1/routes/#{route.id}",
             params: { route: { description: '説明だけ更新' } },

--- a/spec/requests/api/v1/routes_spec.rb
+++ b/spec/requests/api/v1/routes_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe 'Api::V1::Routes', type: :request do
   let(:greentea) { create(:greentea) }
   let(:temple) { create(:temple) }
 
+  # 既定では Directions API を呼ばない（外部依存・実 HTTP を避ける）。
+  # 経路距離・所要時間を検証するテストでは個別に stub し直す。
+  before { allow(DirectionsService).to receive(:leg).and_return(nil) }
+
   # spots: [{ spottable:, transport: }] を順序付きで持つ Route を 1 件作る。
   def create_route_for(owner, spots)
     Route.create!(
@@ -78,6 +82,37 @@ RSpec.describe 'Api::V1::Routes', type: :request do
       get "/api/v1/routes/#{route.id}", headers: auth
       expect(response).to have_http_status(:not_found)
     end
+
+    it 'exposes stored route distance/duration per leg and route totals' do
+      route = create_route_for(user, [{ spottable: temple, transport: :walk }, { spottable: greentea }])
+      route.route_spots.order(:position).first.update!(leg_distance_meters: 1500, leg_duration_seconds: 1080)
+
+      get "/api/v1/routes/#{route.id}", headers: auth
+
+      expect(response).to have_http_status(:ok)
+      data = response.parsed_body['data']
+      spots = data['spots']
+      expect(spots.first['route_distance_to_next_meters']).to eq(1500)
+      expect(spots.first['duration_to_next_seconds']).to eq(1080)
+      expect(spots.last['route_distance_to_next_meters']).to be_nil
+      expect(spots.last['duration_to_next_seconds']).to be_nil
+      expect(data['total_distance_meters']).to eq(1500)
+      expect(data['total_duration_seconds']).to eq(1080)
+    end
+
+    it 'falls back to straight-line distance when no route leg is stored' do
+      route = create_route_for(user, [{ spottable: temple, transport: :walk }, { spottable: greentea }])
+
+      get "/api/v1/routes/#{route.id}", headers: auth
+
+      data = response.parsed_body['data']
+      spots = data['spots']
+      expect(spots.first['route_distance_to_next_meters']).to be_nil
+      expect(spots.first['distance_to_next_meters']).to be_a(Integer)
+      # 経路距離が無い leg は直線距離で合算され、所要時間は nil。
+      expect(data['total_distance_meters']).to eq(spots.first['distance_to_next_meters'])
+      expect(data['total_duration_seconds']).to be_nil
+    end
   end
 
   describe 'POST /api/v1/routes' do
@@ -111,6 +146,26 @@ RSpec.describe 'Api::V1::Routes', type: :request do
       expect(data['spots'].first['spot_type']).to eq('temple')
 
       expect(Route.last.user).to eq(user)
+    end
+
+    it 'computes and stores leg metrics via DirectionsService' do
+      allow(DirectionsService).to receive(:leg)
+        .and_return({ distance_meters: 1500, duration_seconds: 1080 })
+
+      post '/api/v1/routes', params: valid_params, headers: auth
+
+      expect(response).to have_http_status(:created)
+      route = Route.last
+      first_spot = route.route_spots.order(:position).first
+      expect(first_spot.leg_distance_meters).to eq(1500)
+      expect(first_spot.leg_duration_seconds).to eq(1080)
+      # 最後のスポットには次が無いので leg は保存されない。
+      expect(route.route_spots.order(:position).last.leg_distance_meters).to be_nil
+
+      data = response.parsed_body['data']
+      expect(data['spots'].first['route_distance_to_next_meters']).to eq(1500)
+      expect(data['total_distance_meters']).to eq(1500)
+      expect(data['total_duration_seconds']).to eq(1080)
     end
 
     it 'allows duplicate spots in the same route' do

--- a/spec/services/directions_service_spec.rb
+++ b/spec/services/directions_service_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe DirectionsService do
+  let(:origin) { double('origin', latitude: 34.9671, longitude: 135.7727) }
+  let(:destination) { double('destination', latitude: 34.9948, longitude: 135.7850) }
+
+  let(:ok_body) do
+    {
+      'status' => 'OK',
+      'routes' => [
+        { 'legs' => [{ 'distance' => { 'value' => 1500 }, 'duration' => { 'value' => 1080 } }] }
+      ]
+    }
+  end
+
+  describe '.leg' do
+    context 'when no API key is configured' do
+      before { allow(DirectionsService).to receive(:api_key).and_return(nil) }
+
+      it 'returns nil without making a request' do
+        expect(DirectionsService).not_to receive(:request)
+        expect(DirectionsService.leg(origin: origin, destination: destination, mode: 'walk')).to be_nil
+      end
+    end
+
+    context 'when an API key is configured' do
+      before { allow(DirectionsService).to receive(:api_key).and_return('test-key') }
+
+      it 'returns distance and duration from an OK response' do
+        allow(DirectionsService).to receive(:request).and_return(ok_body)
+
+        result = DirectionsService.leg(origin: origin, destination: destination, mode: 'walk')
+        expect(result).to eq(distance_meters: 1500, duration_seconds: 1080)
+      end
+
+      it 'maps walk to mode=walking' do
+        expect(DirectionsService).to receive(:request) do |uri|
+          expect(uri.query).to include('mode=walking')
+          ok_body
+        end
+        DirectionsService.leg(origin: origin, destination: destination, mode: 'walk')
+      end
+
+      it 'maps train to transit + rail' do
+        expect(DirectionsService).to receive(:request) do |uri|
+          expect(uri.query).to include('mode=transit')
+          expect(uri.query).to include('transit_mode=rail')
+          ok_body
+        end
+        DirectionsService.leg(origin: origin, destination: destination, mode: 'train')
+      end
+
+      it 'maps bus to transit + bus' do
+        expect(DirectionsService).to receive(:request) do |uri|
+          expect(uri.query).to include('mode=transit')
+          expect(uri.query).to include('transit_mode=bus')
+          ok_body
+        end
+        DirectionsService.leg(origin: origin, destination: destination, mode: 'bus')
+      end
+
+      it 'defaults an unset transport to walking' do
+        expect(DirectionsService).to receive(:request) do |uri|
+          expect(uri.query).to include('mode=walking')
+          ok_body
+        end
+        DirectionsService.leg(origin: origin, destination: destination, mode: nil)
+      end
+
+      it 'returns nil when the API status is not OK' do
+        allow(DirectionsService).to receive(:request).and_return('status' => 'ZERO_RESULTS', 'routes' => [])
+        expect(DirectionsService.leg(origin: origin, destination: destination, mode: 'walk')).to be_nil
+      end
+
+      it 'returns nil when the request itself fails' do
+        allow(DirectionsService).to receive(:request).and_return(nil)
+        expect(DirectionsService.leg(origin: origin, destination: destination, mode: 'walk')).to be_nil
+      end
+
+      it 'returns nil when coordinates are missing' do
+        no_coords = double('spot', latitude: nil, longitude: nil)
+        expect(DirectionsService).not_to receive(:request)
+        expect(DirectionsService.leg(origin: no_coords, destination: destination, mode: 'walk')).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/directions_service_spec.rb
+++ b/spec/services/directions_service_spec.rb
@@ -77,6 +77,15 @@ RSpec.describe DirectionsService do
         expect(DirectionsService.leg(origin: origin, destination: destination, mode: 'walk')).to be_nil
       end
 
+      it 'returns nil (does not raise) on transient network failures' do
+        [Errno::ECONNRESET, Errno::ECONNREFUSED, EOFError, Net::ReadTimeout].each do |error|
+          allow(Net::HTTP).to receive(:start).and_raise(error)
+          expect {
+            expect(DirectionsService.leg(origin: origin, destination: destination, mode: 'walk')).to be_nil
+          }.not_to raise_error
+        end
+      end
+
       it 'returns nil when coordinates are missing' do
         no_coords = double('spot', latitude: nil, longitude: nil)
         expect(DirectionsService).not_to receive(:request)


### PR DESCRIPTION
## 概要

モデルルート（#65 / PR #152）の各スポット間について、選択された**移動手段 `transport` に応じた実経路距離・所要時間**を Google Directions API で算出し、ルート全体のサマリとあわせて返すようにします。

設計方針（issue #153 でのレビューを反映）:
- **書き込み時に計算して保存**: `route_spots` に距離・所要時間カラムを追加し、ルート作成・更新時に算出。詳細 GET は DB から返すだけで高速・外部依存なし
- **専用キー + フォールバック**: `GOOGLE_DIRECTIONS_API_KEY` →（未設定なら）`GOOGLE_MAPS_API_KEY`

## 変更点

### `DirectionsService`（新規）
2 スポット間の経路距離・所要時間を求めるサービス。既存サービス（`OauthUserInfoFetcher`）と同じ `Net::HTTP` + タイムアウト + rescue のパターンを踏襲。

- `transport`(enum) → Google Directions の mode マッピング:
  | transport | mode |
  |---|---|
  | `walk` | `walking` |
  | `car` | `driving` |
  | `train` | `transit` + `transit_mode=rail` |
  | `bus` | `transit` + `transit_mode=bus` |
  | 未設定(nil) | `walking` |
- API キー: `GOOGLE_DIRECTIONS_API_KEY` → `GOOGLE_MAPS_API_KEY` の順で解決
- **キー未設定 / 座標欠落 / API エラー / タイムアウト時は `nil`** を返し、呼び出し側で直線距離フォールバックに委ねる（ルート取得自体は失敗させない）

### データ / コントローラ
- `route_spots` に `leg_distance_meters` / `leg_duration_seconds` を追加（次スポットまでの経路距離・所要時間。最後・算出失敗時は null）
- `Api::V1::RoutesController` の作成・更新（spots 変更時）に `compute_and_store_legs` を追加し、隣接スポット間の leg を算出・保存
  - 外部 API 呼び出しは **DB トランザクション外** で実行

### レスポンス（`RouteDetailSerializer`）
- 各 spot に追加:
  - `route_distance_to_next_meters`: 経路距離（Directions API）。未算出は `null`
  - `duration_to_next_seconds`: 所要時間（秒）。未算出は `null`
  - 既存の `distance_to_next_meters`（直線距離）はそのまま残置
- ルートに追加:
  - `total_distance_meters`: 経路距離合計（経路距離が無い leg は直線距離でフォールバック合算）
  - `total_duration_seconds`: 所要時間合計（算出済みの leg が 1 つも無ければ `null`）

### ドキュメント
- CLAUDE.md の外部 API 一覧・必須環境変数表に Directions API / `GOOGLE_DIRECTIONS_API_KEY` を追記

## テスト

- `spec/services/directions_service_spec.rb`（新規）: mode マッピング・レスポンスのパース・非 OK / 失敗 / 座標欠落 / キー未設定での `nil` 返却を網羅
- `spec/requests/api/v1/routes_spec.rb`: 書き込み時の leg 保存、詳細レスポンスの経路距離・所要時間・合計、直線距離フォールバックを追加
- `bundle exec rspec spec/services spec/requests` … **143 例 green**、RuboCop クリーン
- ※ 実 API は本環境から叩けないため、テストは Directions API 呼び出しをスタブして検証（本番は実 API で動作）

Closes #153


---
_Generated by [Claude Code](https://claude.ai/code/session_01QLNcxdiAmzBAFRdZGCpUAH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Routes now calculate and display distance and duration metrics for each leg, with total route distance and duration aggregated from Google Directions API; falls back to straight-line estimation when detailed metrics unavailable.

* **Documentation**
  * Updated environment variable documentation to include Google Maps and Directions API key configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->