### PR TITLE
feat(infra): production を Cloud Run の HTTPS/Host 認可前提に設定 (#118)

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -121,7 +121,10 @@ jobs:
             echo "DATABASE_URL=${DATABASE_URL}"
             echo "FRONTEND_URL=${FRONTEND_URL}"
             if [ -n "${APP_HOSTS}" ]; then
-              echo "APP_HOSTS=${APP_HOSTS}"
+              # deploy-cloudrun の env_vars はカンマ/改行を区切りとして解釈する。
+              # APP_HOSTS は複数ホストをカンマ区切りで持つため、値内のカンマを
+              # `\,` にエスケープして 1 つの env var として渡す
+              echo "APP_HOSTS=${APP_HOSTS//,/\\,}"
             fi
             echo "JWT_SECRET_KEY=${JWT_SECRET_KEY}"
             echo "RAILS_MASTER_KEY=${RAILS_MASTER_KEY}"

--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -106,6 +106,7 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           FRONTEND_URL: ${{ vars.FRONTEND_URL }}
+          APP_HOSTS: ${{ vars.APP_HOSTS }}
           SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
           JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
@@ -119,6 +120,9 @@ jobs:
             echo "RAILS_ENV=production"
             echo "DATABASE_URL=${DATABASE_URL}"
             echo "FRONTEND_URL=${FRONTEND_URL}"
+            if [ -n "${APP_HOSTS}" ]; then
+              echo "APP_HOSTS=${APP_HOSTS}"
+            fi
             echo "JWT_SECRET_KEY=${JWT_SECRET_KEY}"
             echo "RAILS_MASTER_KEY=${RAILS_MASTER_KEY}"
             echo "GMAP_API=${GMAP_API}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ bundle exec rubocop
 | `FRONTEND_URL` | CORS allowlist。開発: `http://localhost:3000` / 本番: `https://matcha-to-jinja.com`（#113〜） |
 | `JWT_SECRET_KEY` | API 用 JWT 署名（#115〜） |
 | `RAILS_MASTER_KEY` | `credentials.yml.enc` 復号 |
-| `APP_HOSTS`（任意） | 本番の Host Authorization 許可リスト（カンマ区切り）。未設定なら全ホスト許可。設定時は `*.run.app` を自動許可し `/api/v1/health` は除外（#118） |
+| `APP_HOSTS`（任意） | 本番の Host Authorization 追加許可リスト（カンマ区切り）。本番は常時有効で `*.run.app` を自動許可。カスタムドメインは本変数で追加する（未設定でも `*.run.app` のみ許可＝fail-open しない）。`/api/v1/health` は除外（#118） |
 
 ## DB 構成
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ bundle exec rubocop
 | `FRONTEND_URL` | CORS allowlist。開発: `http://localhost:3000` / 本番: `https://matcha-to-jinja.com`（#113〜） |
 | `JWT_SECRET_KEY` | API 用 JWT 署名（#115〜） |
 | `RAILS_MASTER_KEY` | `credentials.yml.enc` 復号 |
+| `APP_HOSTS`（任意） | 本番の Host Authorization 許可リスト（カンマ区切り）。未設定なら全ホスト許可。設定時は `*.run.app` を自動許可し `/api/v1/health` は除外（#118） |
 
 ## DB 構成
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,8 +45,36 @@ Rails.application.configure do
   # config.action_cable.url = "wss://example.com/cable"
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
+  # --- Cloud Run / リバースプロキシ配下での HTTPS 設定 (#118) ---
+  # Cloud Run は TLS を終端し、コンテナへは HTTP + `X-Forwarded-Proto: https`
+  # で転送してくる。assume_ssl を有効にすると Rails はリクエストを SSL とみなす
+  # ため、force_ssl による無限リダイレクトを避けつつ secure cookie / HSTS を
+  # 効かせられる。Rails 7.1+ の設定。
+  config.assume_ssl = true
+
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
+
+  # Cloud Run のヘルスチェック（HTTP プローブ / Uptime check）は内部ホストから
+  # 平文で来ることがあり、force_ssl の 301 リダイレクトで弾かれると 200 を
+  # 期待するプローブが失敗する。ヘルスチェックパスのみ HTTPS 強制から除外する。
+  config.ssl_options = {
+    redirect: { exclude: ->(request) { request.path == "/api/v1/health" } }
+  }
+
+  # --- Host Authorization (#118) ---
+  # 既定（config.hosts が空）は全ホスト許可。`APP_HOSTS`（カンマ区切り）が
+  # 指定された場合のみ許可リスト方式に切り替える。Cloud Run の `*.run.app` は
+  # 常に許可し、ヘルスチェックは内部ホストからでも通るよう除外する。
+  if ENV["APP_HOSTS"].present?
+    config.hosts << /.*\.run\.app\z/
+    ENV["APP_HOSTS"].split(",").map(&:strip).reject(&:empty?).each do |host|
+      config.hosts << host
+    end
+    config.host_authorization = {
+      exclude: ->(request) { request.path == "/api/v1/health" }
+    }
+  end
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,18 +63,20 @@ Rails.application.configure do
   }
 
   # --- Host Authorization (#118) ---
-  # 既定（config.hosts が空）は全ホスト許可。`APP_HOSTS`（カンマ区切り）が
-  # 指定された場合のみ許可リスト方式に切り替える。Cloud Run の `*.run.app` は
-  # 常に許可し、ヘルスチェックは内部ホストからでも通るよう除外する。
+  # 本番では Host Authorization を常時有効化し、許可ホストを明示する（fail-open 回避）。
+  # Cloud Run の `*.run.app` は常に許可。カスタムドメイン等は `APP_HOSTS`
+  # （カンマ区切り）で追加する。`APP_HOSTS` 未設定でも `*.run.app` のみ許可と
+  # なるため、ホスト認可が無効化されることはない。
+  # ヘルスチェックは内部ホストからでも通るよう除外する。
+  config.hosts << /.*\.run\.app\z/
   if ENV["APP_HOSTS"].present?
-    config.hosts << /.*\.run\.app\z/
     ENV["APP_HOSTS"].split(",").map(&:strip).reject(&:empty?).each do |host|
       config.hosts << host
     end
-    config.host_authorization = {
-      exclude: ->(request) { request.path == "/api/v1/health" }
-    }
   end
+  config.host_authorization = {
+    exclude: ->(request) { request.path == "/api/v1/health" }
+  }
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).


### PR DESCRIPTION
## 概要

#118（GCP Cloud Run + Neon デプロイ）のコード側の残作業として、`production` 環境を **Cloud Run の TLS 終端プロキシ配下**で正しく動くように設定します。

Dockerfile / `.dockerignore` / `deploy-cloud-run.yml` / CI（rspec・rubocop）/ health エンドポイントは既に着地済みのため、本 PR は **production.rb の HTTPS / Host Authorization 設定の欠落**を埋めるものです。

> 画像は `greenteas.img` / `temples.img` が string カラム（URL 文字列）で CarrierWave は未マウントのため、#118 の「GCS 画像移行」は現コードでは対象外です。

## 変更内容

### `config/environments/production.rb`
- `config.assume_ssl = true` を有効化
  - Cloud Run は TLS を終端しコンテナへは HTTP + `X-Forwarded-Proto: https` で転送する。Rails にリクエストを SSL とみなさせ、`force_ssl` の無限リダイレクトを回避する（Rails 7.1+ の設定）
- `config.force_ssl = true` を有効化（secure cookie / HSTS / HTTP→HTTPS）
- `config.ssl_options` で `/api/v1/health` を `force_ssl` の 301 リダイレクトから除外
  - Cloud Run のヘルスチェック / Uptime check が内部ホストから平文で来ても 200 を返せるようにする
- `APP_HOSTS`（カンマ区切り）が指定されたときのみ Host Authorization を許可リスト化
  - `*.run.app` は常に許可、`/api/v1/health` は除外
  - **未設定なら従来どおり全ホスト許可**で既存挙動を壊さない

### `.github/workflows/deploy-cloud-run.yml`
- Cloud Run の env vars に `APP_HOSTS`（`vars.APP_HOSTS`）を受け渡し（空なら注入しない）

### `CLAUDE.md`
- 環境変数表に `APP_HOSTS`（任意）を追記

## 検証

- `ruby -c config/environments/production.rb` → Syntax OK
- production 限定の変更のため test 環境・既存 spec への影響なし（`config/**/*` は RuboCop 除外対象）

## この PR に含まない作業（手元 / インフラ側）

GCP プロジェクト / Artifact Registry / Neon アカウント作成、データ移行、`api.matcha-to-jinja.com` のドメイン+SSL、WIF・各 secrets/vars 設定、本番疎通確認。

Closes #118 の一部（コード側 HTTPS/Host 設定）

https://claude.ai/code/session_012KG99nakrVw1hQRABxWRCZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012KG99nakrVw1hQRABxWRCZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional APP_HOSTS support to control allowed hosts for deployments

* **Bug Fixes**
  * Prevented forced SSL/host checks from breaking health checks by excluding the health endpoint

* **Documentation**
  * Added guidance for APP_HOSTS usage, default host allowances, and health-check handling

* **Chores**
  * Updated production SSL/host-authorization behavior for Cloud Run deployments
<!-- end of auto-generated comment: release notes by coderabbit.ai -->