### PR TITLE
test: 未カバーのモデル単体テストと factory を追加 (#156)

### DIFF
--- a/spec/factories/authentications.rb
+++ b/spec/factories/authentications.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :authentication do
+    association :user
+    provider { 'line' }
+    # DB の (provider, uid) は NOT NULL かつ UNIQUE なので uid を一意に振る。
+    sequence(:uid) { |n| format('U%016d', n) }
+  end
+end

--- a/spec/factories/greentea_likes.rb
+++ b/spec/factories/greentea_likes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :greentea_like do
+    association :user
+    association :greentea
+  end
+end

--- a/spec/factories/greenteacomments.rb
+++ b/spec/factories/greenteacomments.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :greenteacomment do
+    association :user
+    association :greentea
+    body { 'とても美味しい抹茶パフェでした。また行きたいです。' }
+  end
+end

--- a/spec/factories/temple_likes.rb
+++ b/spec/factories/temple_likes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :temple_like do
+    association :user
+    association :temple
+  end
+end

--- a/spec/factories/templecomments.rb
+++ b/spec/factories/templecomments.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :templecomment do
+    association :user
+    association :temple
+    body { '静かで落ち着いた良い神社でした。御朱印もいただけます。' }
+  end
+end

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Authentication, type: :model do
+  describe 'factory' do
+    it 'has a valid factory' do
+      expect(build(:authentication)).to be_valid
+    end
+  end
+
+  describe 'associations' do
+    it 'belongs to a user' do
+      expect(create(:authentication).user).to be_a(User)
+    end
+
+    it 'is invalid without a user' do
+      auth = build(:authentication, user: nil)
+      expect(auth).not_to be_valid
+      expect(auth.errors[:user]).to be_present
+    end
+  end
+end

--- a/spec/models/greentea_like_spec.rb
+++ b/spec/models/greentea_like_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe GreenteaLike, type: :model do
+  describe 'factory' do
+    it 'has a valid factory' do
+      expect(build(:greentea_like)).to be_valid
+    end
+  end
+
+  describe 'associations' do
+    it 'belongs to a user and a greentea' do
+      like = create(:greentea_like)
+      expect(like.user).to be_a(User)
+      expect(like.greentea).to be_a(Greentea)
+    end
+  end
+
+  describe 'uniqueness of (user_id, greentea_id)' do
+    let(:user) { create(:user) }
+    let(:greentea) { create(:greentea) }
+
+    before { create(:greentea_like, user: user, greentea: greentea) }
+
+    it 'is invalid when the same user likes the same greentea twice' do
+      duplicate = build(:greentea_like, user: user, greentea: greentea)
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:user_id]).to be_present
+    end
+
+    it 'is valid when a different user likes the same greentea' do
+      expect(build(:greentea_like, user: create(:user), greentea: greentea)).to be_valid
+    end
+
+    it 'is valid when the same user likes a different greentea' do
+      expect(build(:greentea_like, user: user, greentea: create(:greentea))).to be_valid
+    end
+  end
+end

--- a/spec/models/greenteacomment_spec.rb
+++ b/spec/models/greenteacomment_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Greenteacomment, type: :model do
+  describe 'factory' do
+    it 'has a valid factory' do
+      expect(build(:greenteacomment)).to be_valid
+    end
+  end
+
+  describe 'associations' do
+    it 'belongs to a user and a greentea' do
+      comment = create(:greenteacomment)
+      expect(comment.user).to be_a(User)
+      expect(comment.greentea).to be_a(Greentea)
+    end
+  end
+
+  describe 'body validation' do
+    it 'is invalid without a body' do
+      comment = build(:greenteacomment, body: nil)
+      expect(comment).not_to be_valid
+      expect(comment.errors[:body]).to be_present
+    end
+
+    it 'is invalid with a blank body' do
+      expect(build(:greenteacomment, body: '')).not_to be_valid
+    end
+
+    it 'is valid at the 65,535 character boundary' do
+      expect(build(:greenteacomment, body: 'あ' * 65_535)).to be_valid
+    end
+
+    it 'is invalid above the 65,535 character limit' do
+      comment = build(:greenteacomment, body: 'あ' * 65_536)
+      expect(comment).not_to be_valid
+      expect(comment.errors[:body]).to be_present
+    end
+  end
+end

--- a/spec/models/route_spec.rb
+++ b/spec/models/route_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+RSpec.describe Route, type: :model do
+  describe 'factory' do
+    it 'has a valid factory' do
+      expect(build(:route)).to be_valid
+    end
+  end
+
+  describe 'associations' do
+    it 'belongs to a user' do
+      expect(create(:route).user).to be_a(User)
+    end
+
+    it 'has many route_spots' do
+      expect(create(:route).route_spots.first).to be_a(RouteSpot)
+    end
+  end
+
+  describe 'validations' do
+    it 'is invalid without a name' do
+      route = build(:route, name: nil)
+      expect(route).not_to be_valid
+      expect(route.errors[:name]).to be_present
+    end
+
+    it 'is invalid without any route_spots' do
+      route = build(:route)
+      route.route_spots = []
+      expect(route).not_to be_valid
+      expect(route.errors[:route_spots]).to be_present
+    end
+  end
+
+  describe 'route_spots ordering' do
+    it 'returns route_spots ordered by position ascending' do
+      route = create(:route)
+      route.route_spots.destroy_all
+      create(:route_spot, route: route, position: 3, spottable: create(:greentea))
+      create(:route_spot, route: route, position: 1, spottable: create(:temple))
+      create(:route_spot, route: route, position: 2, spottable: create(:greentea))
+
+      expect(route.route_spots.reload.map(&:position)).to eq([1, 2, 3])
+    end
+  end
+
+  describe 'accepts_nested_attributes_for :route_spots' do
+    let(:user) { create(:user) }
+
+    it 'creates nested route_spots on create' do
+      route = Route.create!(
+        user: user,
+        name: 'ネスト作成ルート',
+        route_spots_attributes: [{ spottable: create(:greentea), position: 1 }]
+      )
+      expect(route.route_spots.count).to eq(1)
+    end
+
+    it 'destroys nested route_spots with _destroy' do
+      route = create(:route)
+      first_spot = route.route_spots.first
+      create(:route_spot, route: route, position: 2, spottable: create(:temple))
+
+      route.update!(route_spots_attributes: [{ id: first_spot.id, _destroy: '1' }])
+
+      expect(route.route_spots.reload).not_to include(first_spot)
+    end
+  end
+
+  describe 'dependent: :destroy' do
+    it 'destroys associated route_spots when the route is destroyed' do
+      route = create(:route)
+      create(:route_spot, route: route, position: 2, spottable: create(:temple))
+
+      expect { route.destroy }.to change(RouteSpot, :count).by(-2)
+    end
+  end
+
+  describe 'ransackable allowlist' do
+    it 'allowlists only name and description for attributes' do
+      expect(described_class.ransackable_attributes).to match_array(%w[name description])
+    end
+
+    it 'allowlists only route_spots for associations' do
+      expect(described_class.ransackable_associations).to match_array(%w[route_spots])
+    end
+  end
+end

--- a/spec/models/route_spot_spec.rb
+++ b/spec/models/route_spot_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe RouteSpot, type: :model do
+  describe 'factory' do
+    it 'has a valid factory' do
+      expect(build(:route_spot)).to be_valid
+    end
+  end
+
+  describe 'associations' do
+    it 'belongs to a route' do
+      expect(create(:route_spot, position: 2).route).to be_a(Route)
+    end
+
+    it 'accepts a greentea as polymorphic spottable' do
+      spot = create(:route_spot, position: 2, spottable: create(:greentea))
+      expect(spot.spottable).to be_a(Greentea)
+      expect(spot.spottable_type).to eq('Greentea')
+    end
+
+    it 'accepts a temple as polymorphic spottable' do
+      spot = create(:route_spot, position: 2, spottable: create(:temple))
+      expect(spot.spottable).to be_a(Temple)
+      expect(spot.spottable_type).to eq('Temple')
+    end
+  end
+
+  describe 'transport enum' do
+    it 'defines walk/train/bus/car' do
+      expect(described_class.transports).to eq('walk' => 0, 'train' => 1, 'bus' => 2, 'car' => 3)
+    end
+
+    it 'allows a nil transport (任意項目)' do
+      expect(build(:route_spot, transport: nil)).to be_valid
+    end
+
+    it 'raises for an unknown transport value' do
+      expect { build(:route_spot, transport: 'plane') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe 'position validation' do
+    it 'is invalid without a position' do
+      spot = build(:route_spot, position: nil)
+      expect(spot).not_to be_valid
+      expect(spot.errors[:position]).to be_present
+    end
+
+    it 'is invalid when position is zero' do
+      expect(build(:route_spot, position: 0)).not_to be_valid
+    end
+
+    it 'is invalid when position is negative' do
+      expect(build(:route_spot, position: -1)).not_to be_valid
+    end
+
+    it 'is invalid when position is not an integer' do
+      expect(build(:route_spot, position: 1.5)).not_to be_valid
+    end
+  end
+
+  describe 'spottable_type inclusion' do
+    it 'is invalid for an unsupported spottable_type' do
+      spot = build(:route_spot)
+      spot.spottable_type = 'User'
+      expect(spot).not_to be_valid
+      expect(spot.errors[:spottable_type]).to be_present
+    end
+  end
+
+  describe '.spottable_type_for' do
+    it 'maps "greentea" to "Greentea"' do
+      expect(described_class.spottable_type_for('greentea')).to eq('Greentea')
+    end
+
+    it 'maps "temple" to "Temple"' do
+      expect(described_class.spottable_type_for('temple')).to eq('Temple')
+    end
+
+    it 'returns nil for an unknown spot type' do
+      expect(described_class.spottable_type_for('unknown')).to be_nil
+    end
+  end
+
+  describe '#spot_type' do
+    it 'returns "greentea" for a Greentea spottable' do
+      expect(build(:route_spot, spottable: build(:greentea)).spot_type).to eq('greentea')
+    end
+
+    it 'returns "temple" for a Temple spottable' do
+      expect(build(:route_spot, spottable: build(:temple)).spot_type).to eq('temple')
+    end
+  end
+end

--- a/spec/models/temple_like_spec.rb
+++ b/spec/models/temple_like_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe TempleLike, type: :model do
+  describe 'factory' do
+    it 'has a valid factory' do
+      expect(build(:temple_like)).to be_valid
+    end
+  end
+
+  describe 'associations' do
+    it 'belongs to a user and a temple' do
+      like = create(:temple_like)
+      expect(like.user).to be_a(User)
+      expect(like.temple).to be_a(Temple)
+    end
+  end
+
+  describe 'uniqueness of (user_id, temple_id)' do
+    let(:user) { create(:user) }
+    let(:temple) { create(:temple) }
+
+    before { create(:temple_like, user: user, temple: temple) }
+
+    it 'is invalid when the same user likes the same temple twice' do
+      duplicate = build(:temple_like, user: user, temple: temple)
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:user_id]).to be_present
+    end
+
+    it 'is valid when a different user likes the same temple' do
+      expect(build(:temple_like, user: create(:user), temple: temple)).to be_valid
+    end
+
+    it 'is valid when the same user likes a different temple' do
+      expect(build(:temple_like, user: user, temple: create(:temple))).to be_valid
+    end
+  end
+end

--- a/spec/models/templecomment_spec.rb
+++ b/spec/models/templecomment_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Templecomment, type: :model do
+  describe 'factory' do
+    it 'has a valid factory' do
+      expect(build(:templecomment)).to be_valid
+    end
+  end
+
+  describe 'associations' do
+    it 'belongs to a user and a temple' do
+      comment = create(:templecomment)
+      expect(comment.user).to be_a(User)
+      expect(comment.temple).to be_a(Temple)
+    end
+  end
+
+  describe 'body validation' do
+    it 'is invalid without a body' do
+      comment = build(:templecomment, body: nil)
+      expect(comment).not_to be_valid
+      expect(comment.errors[:body]).to be_present
+    end
+
+    it 'is invalid with a blank body' do
+      expect(build(:templecomment, body: '')).not_to be_valid
+    end
+
+    it 'is valid at the 65,535 character boundary' do
+      expect(build(:templecomment, body: 'あ' * 65_535)).to be_valid
+    end
+
+    it 'is invalid above the 65,535 character limit' do
+      comment = build(:templecomment, body: 'あ' * 65_536)
+      expect(comment).not_to be_valid
+      expect(comment.errors[:body]).to be_present
+    end
+  end
+end


### PR DESCRIPTION
## 概要

API の request spec は一通り揃っている一方で、ロジックや制約を持つモデルの単体テスト（model spec）が未実装のものがありました。これらを補完します（#156）。

API の正準テスト（request spec）と既存 system spec は対象外で、一切変更していません。

## 追加した factory

- `greentea_like` / `temple_like`
- `greenteacomment` / `templecomment`
- `authentication`（DB の `(provider, uid)` NOT NULL・UNIQUE を満たすよう `uid` を sequence で一意化）

## 追加した model spec

### Phase 1: いいね / コメント系
- `GreenteaLike` / `TempleLike`: 関連、factory 妥当性、`(user_id, *_id)` 一意性（重複で invalid / 別ユーザー・別スポットは valid）
- `Greenteacomment` / `Templecomment`: 関連、`body` presence、長さ上限 65,535 の境界値（65,535=valid / 65,536=invalid）

### Phase 2: Authentication
- `Authentication`: `belongs_to :user`、factory 妥当性、user 欠損で invalid

### Phase 3: モデルルート系
- `RouteSpot`: polymorphic `spottable`（greentea / temple）、`enum transport`、`position`（presence / 整数 / `> 0`）、`spottable_type` inclusion、クラスメソッド `spottable_type_for` / インスタンスメソッド `spot_type`
- `Route`: 関連、`name` presence、`route_spots` presence、`position` 昇順、`accepts_nested_attributes_for`（作成 / `_destroy`）、`dependent: :destroy`、ransackable allowlist

## 方針 / 注意

- API の正準テスト（request spec）はこの PR の対象外（既存を破壊しない）
- 既存 system spec は破壊しない
- テーブル名 `greenteacomments` / `templecomments`（アンダースコアなし）はそのまま扱う（CLAUDE.md）

## 検証

- 新規 model spec: 53 examples, 0 failures
- `spec/models` 全体: 60 examples, 0 failures, 7 pending（pending は既存スタブのままで、本 PR では未着手＝破壊なし）
- RuboCop: 新規 12 ファイル no offenses

Closes #156

---
_Generated by [Claude Code](https://claude.ai/code/session_011DxJjh4YxugpvSzYA428Vj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for authentication, likes, comments, and route functionality with factory definitions and validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->