### PR TITLE
fix(api): genres / areas をページネーションせず全件返す

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,8 +164,8 @@ GET    /api/v1/greenteas              # 一覧。q[name_cont] / q[genres_id_eq] 
 GET    /api/v1/greenteas/:id          # 詳細 + nearby_temples（≤1.5km）
 GET    /api/v1/temples                # 一覧
 GET    /api/v1/temples/:id            # 詳細 + nearby_greenteas
-GET    /api/v1/genres
-GET    /api/v1/areas
+GET    /api/v1/genres                 # 全件返す（ページネーションなし・meta なし）
+GET    /api/v1/areas                  # 全件返す（ページネーションなし・meta なし）
 GET    /api/v1/nearby?lat&lng&radius  # 現在地から radius km 以内
 POST   /api/v1/auth/:provider         # OAuth → JWT 発行
 GET    /api/v1/current_user

--- a/app/controllers/api/v1/areas_controller.rb
+++ b/app/controllers/api/v1/areas_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class AreasController < BaseController
       def index
-        render_collection(paginate(Area.order(:id)), serializer: AreaSerializer)
+        render_full_collection(Area.order(:id), serializer: AreaSerializer)
       end
     end
   end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -72,6 +72,13 @@ module Api
         render json: { data: flatten_serialized(serialized[:data]) }
       end
 
+      # ジャンル / エリアのような件数の少ない参照リストはページネーションせず全件返す。
+      # フロントの絞り込み選択肢が欠落しないよう meta は付けない。
+      def render_full_collection(records, serializer:, serializer_params: {})
+        serialized = serializer.new(records.to_a, params: serializer_params).serializable_hash
+        render json: { data: flatten_serialized(serialized[:data]) }
+      end
+
       def pagination_meta(records)
         {
           current_page: records.current_page,

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -74,6 +74,8 @@ module Api
 
       # ジャンル / エリアのような件数の少ない参照リストはページネーションせず全件返す。
       # フロントの絞り込み選択肢が欠落しないよう meta は付けない。
+      # NOTE: 全件をメモリにロードするため、件数の少ない参照リスト専用。
+      #       大量データを持つテーブルには使わないこと（一覧は render_collection を使う）。
       def render_full_collection(records, serializer:, serializer_params: {})
         serialized = serializer.new(records.to_a, params: serializer_params).serializable_hash
         render json: { data: flatten_serialized(serialized[:data]) }

--- a/app/controllers/api/v1/genres_controller.rb
+++ b/app/controllers/api/v1/genres_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class GenresController < BaseController
       def index
-        render_collection(paginate(Genre.order(:id)), serializer: GenreSerializer)
+        render_full_collection(Genre.order(:id), serializer: GenreSerializer)
       end
     end
   end

--- a/spec/requests/api/v1/areas_spec.rb
+++ b/spec/requests/api/v1/areas_spec.rb
@@ -21,15 +21,14 @@ RSpec.describe 'Api::V1::Areas', type: :request do
       expect(ids).to eq(ids.sort)
     end
 
-    it 'includes pagination meta' do
+    it 'does not paginate and returns all areas without meta' do
+      create_list(:area, 20)
+
       get '/api/v1/areas'
 
-      expect(response.parsed_body['meta']).to include(
-        'current_page' => 1,
-        'total_pages' => 1,
-        'total_count' => 2,
-        'per_page' => 15
-      )
+      json = response.parsed_body
+      expect(json['data'].size).to eq(22)
+      expect(json).not_to have_key('meta')
     end
   end
 end

--- a/spec/requests/api/v1/areas_spec.rb
+++ b/spec/requests/api/v1/areas_spec.rb
@@ -22,12 +22,14 @@ RSpec.describe 'Api::V1::Areas', type: :request do
     end
 
     it 'does not paginate and returns all areas without meta' do
+      # デフォルトの per_page(15) を超える件数を用意し、全件返ることを確認する。
       create_list(:area, 20)
 
       get '/api/v1/areas'
 
       json = response.parsed_body
-      expect(json['data'].size).to eq(22)
+      expect(json['data'].size).to be > 15
+      expect(json['data'].size).to eq(Area.count)
       expect(json).not_to have_key('meta')
     end
   end

--- a/spec/requests/api/v1/genres_spec.rb
+++ b/spec/requests/api/v1/genres_spec.rb
@@ -22,12 +22,14 @@ RSpec.describe 'Api::V1::Genres', type: :request do
     end
 
     it 'does not paginate and returns all genres without meta' do
+      # デフォルトの per_page(15) を超える件数を用意し、全件返ることを確認する。
       create_list(:genre, 20)
 
       get '/api/v1/genres'
 
       json = response.parsed_body
-      expect(json['data'].size).to eq(22)
+      expect(json['data'].size).to be > 15
+      expect(json['data'].size).to eq(Genre.count)
       expect(json).not_to have_key('meta')
     end
   end

--- a/spec/requests/api/v1/genres_spec.rb
+++ b/spec/requests/api/v1/genres_spec.rb
@@ -21,15 +21,14 @@ RSpec.describe 'Api::V1::Genres', type: :request do
       expect(ids).to eq(ids.sort)
     end
 
-    it 'includes pagination meta' do
+    it 'does not paginate and returns all genres without meta' do
+      create_list(:genre, 20)
+
       get '/api/v1/genres'
 
-      expect(response.parsed_body['meta']).to include(
-        'current_page' => 1,
-        'total_pages' => 1,
-        'total_count' => 2,
-        'per_page' => 15
-      )
+      json = response.parsed_body
+      expect(json['data'].size).to eq(22)
+      expect(json).not_to have_key('meta')
     end
   end
 end


### PR DESCRIPTION
## 概要

API レスポンスの契約突き合わせ（実レスポンスを出力して `migration-plan.md` の契約と比較）で判明した不一致を修正します。

`GET /api/v1/genres` と `GET /api/v1/areas` は他の一覧と同じくページネーション（`per_page` 既定 15）されており、`{data:[...], meta:{...}}` を返していました。ジャンル / エリアはフロントの**絞り込み選択肢用の参照リスト**のため、件数が 16 を超えると 16 件目以降が欠落し、フィルタに出てこない不具合になります。

ページネーションせず**全件**を返すよう変更します。

## 変更内容

- `Api::V1::BaseController#render_full_collection` を追加（全件・`meta` なし）
- `GenresController` / `AreasController` を `render_full_collection` に変更
- request spec を「ページネーションしない・`meta` を含まない・全件返す」検証に更新（20件超でも全件返ることを確認）
- `CLAUDE.md` のエンドポイント記述を更新

## レスポンス形（変更後）

```jsonc
GET /api/v1/genres
{
  "data": [ { "id": 1, "name": "パフェ" }, ... ]   // 全件・meta なし
}
```

## 検証

- `spec/requests/api/v1`（genres / areas 含む全体）: 132 examples, 0 failures
- RuboCop: 変更ファイル no offenses

> 補足: 本対応は安全側の予防修正です。`{data:[...]}`（`meta` なし）という最終形がフロント `migration-plan.md` の期待と一致するかは、matcha-to-jinja 側の原本で最終確認してください（bare 配列を期待している場合は `data` ラッパーの有無を合わせます）。

---
_Generated by [Claude Code](https://claude.ai/code/session_011DxJjh4YxugpvSzYA428Vj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `GET /api/v1/genres` endpoint returning all genres without pagination
  * Added `GET /api/v1/areas` endpoint returning all areas without pagination

* **Documentation**
  * Updated API documentation for the new endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->