### PR TITLE
refactor: API の likes / routes コントローラを軽微改善

### DIFF
--- a/app/controllers/api/v1/greentea_likes_controller.rb
+++ b/app/controllers/api/v1/greentea_likes_controller.rb
@@ -19,22 +19,9 @@ module Api
       def create
         greentea = Greentea.find(params[:greentea_id])
         current_user.greentea_likes.find_or_create_by!(greentea: greentea)
-
-        render json: {
-          data: {
-            greentea_id: greentea.id,
-            liked: true,
-            like_count: greentea.greentea_likes.count
-          }
-        }, status: :ok
+        render_like_state(greentea.id, liked: true)
       rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
-        render json: {
-          data: {
-            greentea_id: greentea.id,
-            liked: true,
-            like_count: greentea.greentea_likes.count
-          }
-        }, status: :ok
+        render_like_state(greentea.id, liked: true)
       end
 
       def destroy
@@ -43,10 +30,16 @@ module Api
         return render_not_found unless like
 
         like.destroy!
+        render_like_state(greentea_id, liked: false)
+      end
+
+      private
+
+      def render_like_state(greentea_id, liked:)
         render json: {
           data: {
             greentea_id: greentea_id,
-            liked: false,
+            liked: liked,
             like_count: GreenteaLike.where(greentea_id: greentea_id).count
           }
         }, status: :ok

--- a/app/controllers/api/v1/routes_controller.rb
+++ b/app/controllers/api/v1/routes_controller.rb
@@ -87,10 +87,10 @@ module Api
       # API の spots 配列（順序 = ルート順）から polymorphic な RouteSpot を組み立てる。
       def build_spots(route, spots)
         spots.each_with_index do |spot, index|
-          spottable_type = RouteSpot.spottable_type_for(spot[:spot_type])
-          raise InvalidSpotError, "invalid spot_type: #{spot[:spot_type]}" unless spottable_type
+          record_class = RouteSpot.spottable_class_for(spot[:spot_type])
+          raise InvalidSpotError, "invalid spot_type: #{spot[:spot_type]}" unless record_class
 
-          record = spottable_type.constantize.find_by(id: spot[:spot_id])
+          record = record_class.find_by(id: spot[:spot_id])
           raise InvalidSpotError, "#{spot[:spot_type]} ##{spot[:spot_id]} not found" unless record
 
           route.route_spots.build(

--- a/app/controllers/api/v1/temple_likes_controller.rb
+++ b/app/controllers/api/v1/temple_likes_controller.rb
@@ -19,22 +19,9 @@ module Api
       def create
         temple = Temple.find(params[:temple_id])
         current_user.temple_likes.find_or_create_by!(temple: temple)
-
-        render json: {
-          data: {
-            temple_id: temple.id,
-            liked: true,
-            like_count: temple.temple_likes.count
-          }
-        }, status: :ok
+        render_like_state(temple.id, liked: true)
       rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
-        render json: {
-          data: {
-            temple_id: temple.id,
-            liked: true,
-            like_count: temple.temple_likes.count
-          }
-        }, status: :ok
+        render_like_state(temple.id, liked: true)
       end
 
       def destroy
@@ -43,10 +30,16 @@ module Api
         return render_not_found unless like
 
         like.destroy!
+        render_like_state(temple_id, liked: false)
+      end
+
+      private
+
+      def render_like_state(temple_id, liked:)
         render json: {
           data: {
             temple_id: temple_id,
-            liked: false,
+            liked: liked,
             like_count: TempleLike.where(temple_id: temple_id).count
           }
         }, status: :ok

--- a/app/models/route_spot.rb
+++ b/app/models/route_spot.rb
@@ -16,6 +16,16 @@ class RouteSpot < ApplicationRecord
     SPOT_TYPES[spot_type.to_s]
   end
 
+  # API で受け取る "greentea" / "temple" を ActiveRecord のモデルクラスに解決する。
+  # ユーザー入力文字列を直接 constantize せず、allowlist (SPOT_TYPES) 経由でのみ解決する。
+  # 未対応の spot_type は nil を返す。
+  def self.spottable_class_for(spot_type)
+    case spottable_type_for(spot_type)
+    when 'Greentea' then Greentea
+    when 'Temple' then Temple
+    end
+  end
+
   # ActiveRecord のクラス名を API の "greentea" / "temple" に戻す。
   def spot_type
     SPOT_TYPES.key(spottable_type)

--- a/spec/models/route_spot_spec.rb
+++ b/spec/models/route_spot_spec.rb
@@ -82,6 +82,20 @@ RSpec.describe RouteSpot, type: :model do
     end
   end
 
+  describe '.spottable_class_for' do
+    it 'maps "greentea" to Greentea' do
+      expect(described_class.spottable_class_for('greentea')).to eq(Greentea)
+    end
+
+    it 'maps "temple" to Temple' do
+      expect(described_class.spottable_class_for('temple')).to eq(Temple)
+    end
+
+    it 'returns nil for an unknown spot type' do
+      expect(described_class.spottable_class_for('unknown')).to be_nil
+    end
+  end
+
   describe '#spot_type' do
     it 'returns "greentea" for a Greentea spottable' do
       expect(build(:route_spot, spottable: build(:greentea)).spot_type).to eq('greentea')


### PR DESCRIPTION
## 概要

issue 化されていない既存コードの軽微な改善です。レビュー時に見つかった点のうち、API（`api/v1`）の `likes` / `routes` 周りをリファクタしました。**レスポンス契約・挙動は一切変えていません**（lint / 可読性 / 保守性の向上のみ）。

## 変更内容

### 1. routes: 動的 `constantize` を allowlist 経由のクラス解決に置換
- `RoutesController#build_spots` で `spottable_type.constantize` を呼んでいた箇所を、`RouteSpot.spottable_class_for` 経由に変更。
- `spottable_class_for` は `SPOT_TYPES`（凍結 allowlist）経由でのみ `Greentea` / `Temple` を返し、ユーザー入力文字列を直接 `constantize` しない。
- 元々 `spottable_type_for` の allowlist チェック後の値しか渡らず**安全**でしたが、Brakeman 等の静的解析が「動的 constantize」として黄旗を立てるパターンだったため、予防的に解消。

### 2. likes: create / destroy の重複レスポンス生成を集約
- `greentea_likes` / `temple_likes` の `create` の通常分岐と rescue 分岐で重複していた JSON 生成を `render_like_state` に集約。
- `like_count` の集計を `where(*_id:).count` に統一。
- レスポンスのキー（`*_id` / `liked` / `like_count`）と値は従来と同一。

### 3. spec
- `RouteSpot.spottable_class_for` のテストを追加（`greentea` → `Greentea` / `temple` → `Temple` / 不明 → `nil`）。

## テスト

- ローカルは Ruby バージョン差（env 3.3.6 / Gemfile 3.3.11）で `bundle install` が通らず rspec 未実行のため、検証は CI に委ねています。
- 変更ファイルは `ruby -c` で構文チェック済み（全て Syntax OK）。
- 既存の like / routes の request spec が期待するレスポンス契約は変更していません。

## 補足

- 関連 issue なし（レビューで発見した独立した軽微改善のため）。
- README のバージョン陳腐化や `config.load_defaults 7.1` 化（#124 の仕上げ）は本 PR の範囲外です。

https://claude.ai/code/session_013zxWJ8iLQHqGFzFMfaANpc

---
_Generated by [Claude Code](https://claude.ai/code/session_013zxWJ8iLQHqGFzFMfaANpc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate response logic for like operations across multiple endpoints to improve consistency and maintainability.
  * Improved internal handling of polymorphic type resolution with better validation and error handling.

* **Tests**
  * Added test coverage for polymorphic type mapping functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->