### PR TITLE
fix: RuboCop 1.87 の Style/RedundantParentheses 違反を解消

### DIFF
--- a/spec/models/greentea_spec.rb
+++ b/spec/models/greentea_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Greentea, type: :model do
     it 'returns a positive distance in meters rounded to the nearest 10' do
       distance = greentea.get_distance(34.99, 135.0)
       expect(distance).to be > 0
-      expect((distance % 10)).to be_zero
+      expect(distance % 10).to be_zero
     end
   end
 

--- a/spec/models/temple_spec.rb
+++ b/spec/models/temple_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Temple, type: :model do
     it 'returns a positive distance in meters rounded to the nearest 10' do
       distance = temple.get_distance(34.99, 135.0)
       expect(distance).to be > 0
-      expect((distance % 10)).to be_zero
+      expect(distance % 10).to be_zero
     end
   end
 


### PR DESCRIPTION
## 概要

Dependabot の RuboCop 更新 PR **#169（rubocop 1.36.0 → 1.87.0）** で、RuboCop ジョブのみが失敗していました。新しい RuboCop が既存の spec に対して `Style/RedundantParentheses` を検出するためです（RSpec request / model / helper・system は両方とも成功）。

本 PR で該当箇所の冗長な括弧を除去し、RuboCop 1.87 でも通るようにします。

## 失敗内容

```
spec/models/greentea_spec.rb:62:14: C: [Correctable] Style/RedundantParentheses
spec/models/temple_spec.rb:62:14: C: [Correctable] Style/RedundantParentheses
      expect((distance % 10)).to be_zero
```

## 変更点

- `spec/models/greentea_spec.rb`
- `spec/models/temple_spec.rb`

いずれも `get_distance` のテストで、

```ruby
expect((distance % 10)).to be_zero   # before
expect(distance % 10).to be_zero     # after
```

と冗長な括弧を外しました。意味は変わりません（RuboCop の autocorrect と同一の修正）。

## #169 との関係

本 PR を main にマージ後、Dependabot が #169 を自動 rebase すれば RuboCop ジョブが通るようになります。先に取り込むことで puma の CVE 対応 (#166) を含む他の依存更新 PR とは独立して RuboCop の lint 失敗を解消できます。

## 動作確認

- ローカルは Ruby バージョン差異（3.3.6 / Gemfile は 3.3.11）で bundle 実行不可のため、CI で検証します。
- 変更は冗長括弧の除去のみで挙動への影響なし。


---
_Generated by [Claude Code](https://claude.ai/code/session_01LHRSq7MKHdYqSs7RJ78Bft)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test assertion formatting across multiple test files for enhanced code readability. Removed redundant parentheses from distance validation checks without introducing behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->