### PR TITLE
fix: puma の bind ホストを 0.0.0.0 に明示固定

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -14,8 +14,11 @@ threads min_threads_count, max_threads_count
 worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
+# Bind host is pinned to IPv4 0.0.0.0 explicitly. Puma 8 changed the default
+# production bind host from 0.0.0.0 to :: (IPv6); Cloud Run expects the container
+# to listen on 0.0.0.0:$PORT, so we keep the historical IPv4 behavior.
 #
-port ENV.fetch("PORT") { 3000 }
+port ENV.fetch("PORT") { 3000 }, "0.0.0.0"
 # if ENV.fetch('RAILS_ENV') { 'development' } == 'development'
 #   ssl_bind '0.0.0.0', '9292', key: "config/certs/localhost-key.pem", cert: "config/certs/localhost.pem"
 # end


### PR DESCRIPTION
## 概要

puma 8 への更新（#166）で、**本番のデフォルト bind ホストが `0.0.0.0` から `::`（IPv6）に変更**されました（非ループバック IPv6 が利用可能な場合。利用不可なら `0.0.0.0` にフォールバック）。

`config/puma.rb` は `port` のみ指定でホストを明示していなかったため、このデフォルト変更の影響を受けます。Cloud Run はコンテナが `0.0.0.0:$PORT` で待ち受けることを前提とする（#118）ため、IPv6 のみで bind されると疎通しないリスクがあります。

本 PR で bind ホストを **`0.0.0.0` に明示固定**し、puma のバージョンに依存せず従来どおりの IPv4 bind 挙動を維持します。

## 変更点

`config/puma.rb`

```ruby
port ENV.fetch("PORT") { 3000 }            # before
port ENV.fetch("PORT") { 3000 }, "0.0.0.0" # after
```

- 挙動は puma 5 時代と同一（既存の本番動作を変えない純粋な防御策）
- Cloud Run 移行（#118）での bind 不整合リスクを事前に解消

## 背景

- puma 8.0.0 Breaking changes: `Default production bind address changed from 0.0.0.0 to :: (IPv6) when a non-loopback IPv6 interface is available`
- 関連: #166（puma 5.6.5 → 8.0.2）, #118（GCP Cloud Run 移行）

## 動作確認

- 設定値の明示化のみで、ローカル / CI の挙動に変化なし（CI で検証）。


---
_Generated by [Claude Code](https://claude.ai/code/session_01LHRSq7MKHdYqSs7RJ78Bft)_