### PR TITLE
docs/ci: デプロイ手順書の追加と deploy workflow の Actions を SHA ピン

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -59,15 +59,13 @@ jobs:
           echo "base=${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${AR_REPOSITORY}/${SERVICE_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate to Google Cloud
-        # TODO(#118): 安定後に SHA ピンする。現状は機能確認のため v2 タグを使用
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_DEPLOY_SERVICE_ACCOUNT }}
 
       - name: Set up gcloud
-        # TODO(#118): SHA ピン
-        uses: google-github-actions/setup-gcloud@v3
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
 
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker ${{ env.GCP_REGION }}-docker.pkg.dev --quiet
@@ -139,8 +137,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Deploy to Cloud Run
-        # TODO(#118): SHA ピン（v2 のリリース安定後に切替）
-        uses: google-github-actions/deploy-cloudrun@v3
+        uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3
         with:
           service: ${{ env.SERVICE_NAME }}
           region: ${{ env.GCP_REGION }}

--- a/docs/infra/deploy-runbook.md
+++ b/docs/infra/deploy-runbook.md
@@ -1,0 +1,268 @@
+# デプロイ手順書（GCP Cloud Run + Neon PostgreSQL）
+
+> 抹茶と神社。(greentea_temple) Rails API を **GCP Cloud Run** にデプロイするための実作業手順書。
+> 関連 issue: #118（GCP Cloud Run + Neon PostgreSQL デプロイ）
+> コスト・構成の背景は [`deploy-cost-comparison.md`](./deploy-cost-comparison.md) を参照。
+> 最終更新: 2026-06-16
+
+## 0. 前提と現状
+
+- デプロイ定義はコード側に**すでに揃っている**:
+  - `Dockerfile`（multi-stage / assets precompile / bootsnap / 非 root 起動）
+  - `.dockerignore`
+  - `.github/workflows/ci.yml`（RuboCop / RSpec / system spec）
+  - `.github/workflows/deploy-cloud-run.yml`（Build → Artifact Registry → Cloud Run deploy）
+- `deploy-cloud-run.yml` は現状 **手動トリガ（`workflow_dispatch`）のみ**。
+  GCP 側のセットアップと各 secrets / vars が揃ったら `main` push 自動デプロイに切り替える。
+- 構成図:
+
+  ```text
+  [ユーザー] → Vercel(Next.js) → Cloud Run(Rails API) → Neon(PostgreSQL)
+                                         └→ GCS(画像配信 ※未実装・将来対応)
+  ```
+
+- リージョンは `asia-northeast1`（東京）、サービス名 `greentea-temple`。
+- **未実装の注意**: 画像の GCS 配信は**まだコード未対応**（`fog-google` 未導入）。
+  初回デプロイは GCS 抜きで進め、GCS 化は別タスクとする（本書「7. 将来対応」）。
+
+---
+
+## 1. 必要なもの（事前準備）
+
+- GCP アカウントと課金有効なプロジェクト（無料枠内運用想定）
+- `gcloud` CLI（ローカル or Cloud Shell）
+- Neon アカウント（東京リージョン）
+- このリポジトリの GitHub 管理者権限（Secrets / Variables 設定のため）
+- 既存 DB のデータ（移行する場合のバックアップ）
+
+以下、シェル変数を使い回す:
+
+```bash
+export PROJECT_ID=<your-gcp-project-id>
+export REGION=asia-northeast1
+export REPO=greentea-temple          # Artifact Registry リポジトリ名（= GitHub vars.AR_REPOSITORY）
+export SERVICE=greentea-temple        # Cloud Run サービス名（workflow の SERVICE_NAME と一致）
+```
+
+---
+
+## 2. GCP 一回限りのセットアップ
+
+### 2-1. プロジェクト設定 & API 有効化
+
+```bash
+gcloud config set project "$PROJECT_ID"
+gcloud services enable \
+  run.googleapis.com \
+  artifactregistry.googleapis.com \
+  iamcredentials.googleapis.com \
+  sts.googleapis.com
+```
+
+### 2-2. Artifact Registry（Docker イメージ置き場）
+
+```bash
+gcloud artifacts repositories create "$REPO" \
+  --repository-format=docker \
+  --location="$REGION" \
+  --description="greentea_temple container images"
+```
+
+> イメージの肥大を防ぐため、安定後に lifecycle policy で世代を絞ること（本書「6. 運用」）。
+
+### 2-3. デプロイ用サービスアカウント
+
+```bash
+gcloud iam service-accounts create gh-deployer \
+  --display-name="GitHub Actions deployer"
+
+export SA="gh-deployer@${PROJECT_ID}.iam.gserviceaccount.com"
+
+for role in \
+  roles/run.admin \
+  roles/artifactregistry.writer \
+  roles/iam.serviceAccountUser; do
+  gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+    --member="serviceAccount:${SA}" \
+    --role="$role"
+done
+```
+
+> Cloud Run のランタイム SA（デフォルトは Compute Engine default SA）にも、
+> Neon は外部接続なので追加権限は不要。GCS 化する場合のみ後で storage 権限を付与する。
+
+### 2-4. Workload Identity Federation（鍵レス認証）
+
+GitHub Actions が JSON 鍵なしで GCP に認証するための設定。
+
+```bash
+export PROJECT_NUMBER=$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')
+
+# Pool
+gcloud iam workload-identity-pools create github \
+  --location=global \
+  --display-name="GitHub Actions Pool"
+
+# Provider（このリポジトリからのトークンのみ受け付ける）
+gcloud iam workload-identity-pools providers create-oidc github-actions \
+  --location=global \
+  --workload-identity-pool=github \
+  --display-name="GitHub Actions Provider" \
+  --issuer-uri="https://token.actions.githubusercontent.com" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository" \
+  --attribute-condition="assertion.repository=='hiiragi17/greentea_temple'"
+
+# このリポジトリの実行だけが SA を借りられるよう紐付け
+gcloud iam service-accounts add-iam-policy-binding "$SA" \
+  --role=roles/iam.workloadIdentityUser \
+  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github/attribute.repository/hiiragi17/greentea_temple"
+```
+
+GitHub Secrets に登録する **provider のリソース名** を控える:
+
+```bash
+echo "projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github/providers/github-actions"
+# → これを secret GCP_WORKLOAD_IDENTITY_PROVIDER に設定
+echo "$SA"
+# → これを secret GCP_DEPLOY_SERVICE_ACCOUNT に設定
+```
+
+---
+
+## 3. Neon PostgreSQL セットアップ
+
+1. Neon でプロジェクトを **東京リージョン**で作成。
+2. 開発用 / 本番用にブランチを分ける。
+3. **Pooled connection** の接続文字列を取得し、SSL を必須にする:
+   - 例: `postgres://<user>:<pass>@<host>-pooler.<region>.aws.neon.tech/<db>?sslmode=require`
+   - Cloud Run の同時実行で接続が枯渇しないよう **pooler 経由**を使う。
+4. 既存 DB からの移行（必要な場合）:
+
+   ```bash
+   # 旧 DB をダンプ
+   pg_dump --no-owner --no-privileges -Fc "$OLD_DATABASE_URL" -f dump.pgsql
+   # Neon へリストア
+   pg_restore --no-owner --no-privileges -d "$NEON_DATABASE_URL" dump.pgsql
+   ```
+
+5. この接続文字列を GitHub Secret `DATABASE_URL` に設定する。
+
+> ⚠️ 新規 DB の場合はスキーマ適用が必要。`bin/rails db:schema:load` を流すか、
+> 初回起動前に migration を当てる運用を決めておく（Cloud Run はリリース時に migration を
+> 自動実行しないため、必要なら別途 Cloud Run Job / 手動で `db:migrate` を実行する）。
+
+---
+
+## 4. GitHub Secrets / Variables 登録
+
+リポジトリ → **Settings → Secrets and variables → Actions**。
+（`deploy-cloud-run.yml` が参照しているキーと完全一致させること）
+
+### Secrets
+
+| キー | 値 | 取得元 |
+|---|---|---|
+| `GCP_PROJECT_ID` | GCP プロジェクト ID | `$PROJECT_ID` |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | WIF provider リソース名 | 2-4 の出力 |
+| `GCP_DEPLOY_SERVICE_ACCOUNT` | デプロイ SA のメール | `$SA` |
+| `DATABASE_URL` | Neon の pooled 接続文字列（`sslmode=require`） | 3 |
+| `RAILS_MASTER_KEY` | `config/master.key` の値 | ローカル |
+| `JWT_SECRET_KEY` | API 用 JWT 署名鍵 | 任意の十分長い乱数 |
+| `GMAP_API` | Geocoding 用 API キー | Google Cloud Console |
+| `GOOGLE_MAP_API` | Maps JS API キー | Google Cloud Console |
+| `LINE_KEY` | LINE OAuth キー | LINE Developers |
+| `LINE_SECRET` | LINE OAuth シークレット | LINE Developers |
+| `SECRET_KEY_BASE` | （任意）未設定なら credentials 由来を使用 | 任意 |
+
+> `SECRET_KEY_BASE` は **secret が存在するときのみ** Cloud Run に渡される実装。
+> credentials.yml.enc 側に持たせるなら未設定で OK（`RAILS_MASTER_KEY` で復号される）。
+
+### Variables
+
+| キー | 値 |
+|---|---|
+| `AR_REPOSITORY` | Artifact Registry リポジトリ名（`$REPO`） |
+| `FRONTEND_URL` | CORS allowlist（本番: `https://matcha-to-jinja.com`） |
+| `APP_HOSTS` | （任意）追加許可ホスト（カンマ区切り）。`*.run.app` は本番で自動許可 |
+
+---
+
+## 5. 初回デプロイ
+
+1. GitHub → **Actions** → **Deploy to Cloud Run** → **Run workflow**。
+   - `image_tag` は空でよい（commit SHA の先頭 12 桁が使われる）。
+2. ジョブの流れ:
+   - WIF で GCP 認証 → `docker build` → Artifact Registry push → `deploy-cloudrun` で Cloud Run へ。
+   - デプロイ flags: `--allow-unauthenticated --memory=512Mi --cpu=1 --min-instances=0 --max-instances=4`。
+3. 最終ステップでサービス URL が出力される。
+
+### 受け入れ確認（#118 の受け入れ条件）
+
+```bash
+curl -i https://<cloud-run-url>/api/v1/health   # → 200 / {"status":"ok"}
+```
+
+- [ ] `/api/v1/health` が 200
+- [ ] フロント（Vercel preview）から CORS エラーなく API を叩ける
+- [ ] スケールトゥゼロから初回レスポンスが返る（コールドスタート許容）
+
+### カスタムドメイン
+
+`api.matcha-to-jinja.com` を Cloud Run にマッピング:
+
+```bash
+gcloud run domain-mappings create \
+  --service="$SERVICE" \
+  --domain=api.matcha-to-jinja.com \
+  --region="$REGION"
+```
+
+表示される DNS レコードをドメイン側に設定。SSL は自動発行。
+
+---
+
+## 6. 確認後の仕上げ（自動化・運用）
+
+1. **自動デプロイ化**: `deploy-cloud-run.yml` の `on:` に以下を追加。
+
+   ```yaml
+   on:
+     push:
+       branches: [main]
+     workflow_dispatch:
+       inputs:
+         image_tag: { ... }   # 既存のまま
+   ```
+
+2. **Actions の SHA ピン**: `google-github-actions/auth@v3` /
+   `setup-gcloud@v3` / `deploy-cloudrun@v3` を安定版のコミット SHA に固定（workflow 内 TODO）。
+3. **Artifact Registry の lifecycle policy**: 古い tag を自動削除し 0.5GB 無料枠を維持。
+4. **コールドスタート対策（任意）**: Cloud Scheduler で `/api/v1/health` を定期的に叩いて
+   Cloud Run をウォーム維持（`/api/v1/health` は DB 非接続なので Neon は温まらない点に注意）。
+   詳細は [`deploy-cost-comparison.md`](./deploy-cost-comparison.md) の「4. 弱点克服 Tips」。
+
+---
+
+## 7. 将来対応（GCS 画像配信・未実装）
+
+現状 `fog-google` 未導入のため、画像の GCS 配信は**コード対応が別途必要**。実装時のタスク:
+
+- [ ] `fog-google` gem 追加
+- [ ] CarrierWave を `production` 環境のみ `:fog`（GCS）へ切替
+- [ ] GCS バケット作成（`asia-northeast1` / 公開読み取り）
+- [ ] Cloud Run ランタイム SA に storage 権限付与
+- [ ] `deploy-cloud-run.yml` の env_vars に `GCP_PROJECT_ID` / `GCS_BUCKET` 等を追加
+- [ ] 既存画像の GCS への移行
+
+---
+
+## 8. トラブルシュート
+
+| 症状 | 確認ポイント |
+|---|---|
+| 認証エラー（`auth` step で失敗） | WIF の `attribute-condition` のリポジトリ名、SA の `workloadIdentityUser` 紐付け、3 つの GCP secret |
+| `docker push` で権限エラー | SA の `roles/artifactregistry.writer`、`AR_REPOSITORY` 変数とリポジトリ名の一致 |
+| 起動後 500 / DB 接続不可 | `DATABASE_URL` の `sslmode=require`、pooler ホスト、Neon オートサスペンドからの復帰 |
+| Host Authorization で弾かれる | `APP_HOSTS` にカスタムドメインを追加（`*.run.app` は本番自動許可） |
+| アセットが出ない | Dockerfile の `assets:precompile` 成否、`RAILS_SERVE_STATIC_FILES=1`（runtime で設定済み） |
+| migration 未反映 | Cloud Run は自動で `db:migrate` しない。Cloud Run Job か手動で実行する |

--- a/docs/infra/deploy-runbook.md
+++ b/docs/infra/deploy-runbook.md
@@ -234,8 +234,8 @@ gcloud run domain-mappings create \
          image_tag: { ... }   # 既存のまま
    ```
 
-2. **Actions の SHA ピン**: `google-github-actions/auth@v3` /
-   `setup-gcloud@v3` / `deploy-cloudrun@v3` を安定版のコミット SHA に固定（workflow 内 TODO）。
+2. ~~**Actions の SHA ピン**~~: 対応済み。`auth` / `setup-gcloud` / `deploy-cloudrun`
+   は `v3` タグの commit SHA に固定済み（`# v3` コメントで版を併記）。
 3. **Artifact Registry の lifecycle policy**: 古い tag を自動削除し 0.5GB 無料枠を維持。
 4. **コールドスタート対策（任意）**: Cloud Scheduler で `/api/v1/health` を定期的に叩いて
    Cloud Run をウォーム維持（`/api/v1/health` は DB 非接続なので Neon は温まらない点に注意）。

--- a/docs/infra/deploy-runbook.md
+++ b/docs/infra/deploy-runbook.md
@@ -170,12 +170,29 @@ echo "$SA"
 | `JWT_SECRET_KEY` | API 用 JWT 署名鍵 | 任意の十分長い乱数 |
 | `GMAP_API` | Geocoding 用 API キー | Google Cloud Console |
 | `GOOGLE_MAP_API` | Maps JS API キー | Google Cloud Console |
-| `LINE_KEY` | LINE OAuth キー | LINE Developers |
-| `LINE_SECRET` | LINE OAuth シークレット | LINE Developers |
+| `LINE_KEY` | LINE OAuth キー（※下記注意） | LINE Developers |
+| `LINE_SECRET` | LINE OAuth シークレット（※下記注意） | LINE Developers |
 | `SECRET_KEY_BASE` | （任意）未設定なら credentials 由来を使用 | 任意 |
 
 > `SECRET_KEY_BASE` は **secret が存在するときのみ** Cloud Run に渡される実装。
 > credentials.yml.enc 側に持たせるなら未設定で OK（`RAILS_MASTER_KEY` で復号される）。
+
+> ⚠️ **LINE OAuth の認証情報は環境変数では読まれない**（重要）
+> `config/initializers/sorcery.rb` は LINE の key/secret を **encrypted credentials** から読む:
+>
+> ```ruby
+> config.line.key    = Rails.application.credentials.dig(:line, :channel_id)
+> config.line.secret = Rails.application.credentials.dig(:line, :channel_secret)
+> ```
+>
+> そのため上表の `LINE_KEY` / `LINE_SECRET` を Cloud Run に渡しても **Sorcery は参照せず、LINE
+> ログインは有効化されない**（`deploy-cloud-run.yml` がこれらを env で渡しているのは現状
+> アプリ側と未整合）。LINE ログインを本番で動かすには、**`credentials.yml.enc` に
+> `line.channel_id` / `line.channel_secret` を設定**し（`RAILS_MASTER_KEY` で復号）、
+> その値を使うこと。GitHub Secrets の `LINE_KEY` / `LINE_SECRET` は現状不要。
+>
+> （根本対応として initializer を `ENV['LINE_KEY']` 参照へ寄せる選択肢もあるが、認証境界に
+> 触れるため本手順書のスコープ外。別 issue で扱う。）
 
 ### Variables
 


### PR DESCRIPTION
## 概要

GCP Cloud Run + Neon へのデプロイ作業を実際に進められるよう、**実作業手順書を追加**し、あわせて `deploy-cloud-run.yml` の **GitHub Actions を commit SHA にピン**しました。

関連: #118（GCP Cloud Run + Neon PostgreSQL デプロイ。Issue 自体はクローズ済みだが、実セットアップの手順書が未整備だったため補完）

## 変更内容

### 1. デプロイ手順書を追加（`docs/infra/deploy-runbook.md`）

`Dockerfile` / `deploy-cloud-run.yml` の実装と対応させた実作業ランブック:

- GCP 一回限りのセットアップ（Artifact Registry / デプロイ用 SA / **Workload Identity Federation** の具体コマンド）
- Neon PostgreSQL セットアップ・データ移行（`pg_dump` → `pg_restore`、pooler + `sslmode=require`）
- **GitHub Secrets / Variables 一覧**（workflow が参照するキーと一致させた表）
- 初回デプロイ・受け入れ確認・カスタムドメイン設定
- 仕上げ（`main` push 自動デプロイ化 / lifecycle policy / コールドスタート対策）
- GCS 画像配信の将来対応（`fog-google` 未導入＝**現状未実装**であることを明記）
- トラブルシュート表

### 2. deploy workflow の Actions を SHA ピン（`.github/workflows/deploy-cloud-run.yml`）

floating タグ参照を `v3` タグの commit SHA に固定し、既存の `TODO(#118): SHA ピン` を解消:

| Action | ピン先 |
|---|---|
| `google-github-actions/auth` | `7c6bc770dae815cd3e89ee6cdf493a5fab2cc093` # v3 |
| `google-github-actions/setup-gcloud` | `aa5489c8933f4cc7a4f7d45035b3b1440c9c10db` # v3 |
| `google-github-actions/deploy-cloudrun` | `2028e2d7d30a78c6910e0632e48dd561b064884d` # v3 |

SHA は各リポジトリの `git/refs/tags/v3`（いずれも commit を直接指す lightweight タグ）から取得しています。

## 補足・注意

- 本 PR は **デプロイの挙動を変えません**。workflow は引き続き手動トリガ（`workflow_dispatch`）のみで、GCP 未設定でも安全です。
- `main` push 自動デプロイ化は、GCP / Neon / Secrets が揃い**初回の手動デプロイが成功してから**行う想定です（手順書「6. 仕上げ」）。

## テスト

- ドキュメント追加と CI 設定ファイルの SHA ピンのみで、アプリのコード変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABg8KEkotNyWwizTLD7zLR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive deployment runbook with step-by-step instructions for deploying to GCP Cloud Run with Neon PostgreSQL, including infrastructure setup and health-check procedures.

* **Chores**
  * Updated deployment workflow with SHA-pinned versions of GitHub Actions for enhanced security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->