### PR TITLE
fix: /privacy_policy が 500 になるアクション名のタイプミスを修正

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -5,5 +5,5 @@ class StaticPagesController < ApplicationController
 
   def terms_of_service; end
 
-  def provacy_policy; end
+  def privacy_policy; end
 end


### PR DESCRIPTION
## 概要

`/privacy_policy` にアクセスすると 500 エラー（`AbstractController::ActionNotFound`）になり、プライバシーポリシーページが表示できない問題を修正しました。

## 原因

ルートが参照するアクション名と、コントローラのメソッド名が一致していませんでした（タイプミス）。

```ruby
# config/routes.rb:47
get 'privacy_policy', to: 'static_pages#privacy_policy'

# app/controllers/static_pages_controller.rb:8（修正前）
def provacy_policy; end   # ← "provacy" は誤り
```

## 変更内容

- `static_pages_controller.rb` のメソッド名を `provacy_policy` → `privacy_policy` に修正

ビュー（`app/views/static_pages/privacy_policy.html.erb`）は元々正しいファイル名のため変更ありません。

## 動作確認

- ルート `privacy_policy` → アクション `privacy_policy` → ビュー `privacy_policy.html.erb` が一致

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BT9vJYtSio3RLmLRDk9tFQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed privacy policy page to be accessible with the correct URL endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->