### PR TITLE
chore: 未使用の jbuilder gem を削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,9 +31,6 @@ gem "stimulus-rails"
 # Bundle and process CSS [https://github.com/rails/cssbundling-rails]
 gem "cssbundling-rails"
 
-# Build JSON APIs with ease [https://github.com/rails/jbuilder]
-gem "jbuilder"
-
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,9 +233,6 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jbuilder (2.15.1)
-      actionview (>= 7.0.0)
-      activesupport (>= 7.0.0)
     jquery-rails (4.5.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -542,7 +539,6 @@ DEPENDENCIES
   geocoder
   geokit-rails
   gon
-  jbuilder
   jsbundling-rails
   jsonapi-serializer (~> 2.2)
   jwt (~> 3.2)


### PR DESCRIPTION
## 概要

未使用の `jbuilder` gem を削除します。

API レスポンスは `jsonapi-serializer`（#114）で実装しており、`jbuilder` は使用していません。調査の結果、以下を確認しました。

- `.json.jbuilder` テンプレート：**0 件**
- アプリケーションコード・config からの参照：**0 件**（`Gemfile` の宣言のみ）

Web フロント撤去（#136）の前提条件に依存せず、今すぐ安全に削除できる unused dependency です。

## 変更内容

- `Gemfile` から `gem "jbuilder"`（と説明コメント）を削除
- `Gemfile.lock` から `jbuilder (2.15.1)` の spec と DEPENDENCIES 参照を削除
  - 他 gem が依存していない leaf のため安全に除去（`actionview` / `activesupport` は rails 経由で残存）

## 影響範囲

- API（`jsonapi-serializer`）に影響なし
- 既存 Web ビュー（ERB）にも影響なし（jbuilder テンプレート未使用）

## 補足

実行環境の Ruby が 3.3.6 で `Gemfile` 指定の 3.3.11 と異なり `bundle install` が走らなかったため、`Gemfile.lock` は手動で該当行のみ除去しています。CI（Ruby 3.3.11）の `bundle` 検証で整合性をご確認ください。

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BT9vJYtSio3RLmLRDk9tFQ)_