### PR TITLE
fix: API レスポンスをフロント契約(fixtures)に合わせてドリフト解消

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,9 +177,9 @@ DELETE /api/v1/greentea_likes/:id     # :id = greentea_id として解決
 
 ### レスポンス共通フィールド（snake_case）
 
-- スポット系: `id, name, address, access, business_hours, holiday, latitude, longitude, img, like_count, liked_by_current_user`
+- スポット系: `id, name, address, access, business_hours, holiday, latitude, longitude, img, likes_count, liked_by_current_user`（`liked_by_current_user` は詳細のみ。一覧は含めない）
 - 近隣配列の各要素: `id, name, latitude, longitude, distance_meters`（整数）
-- 一覧の `meta`: `{ current_page, total_pages, total_count, per_page }`
+- 一覧の `meta`: `{ current_page, total_pages, total_count }`（`per_page` はフロント (matcha-to-jinja) の fixtures が使わないため返さない）
 
 ## コーディング規約
 
@@ -194,7 +194,7 @@ DELETE /api/v1/greentea_likes/:id     # :id = greentea_id として解決
 
 - API レスポンスは `jsonapi-serializer` を使う（#114 で導入）
 - 詳細用の `nearby_*` は専用 serializer に切り出す（距離情報を含むため）
-- 一覧の `meta` は `{ current_page, total_pages, total_count, per_page }` で統一
+- 一覧の `meta` は `{ current_page, total_pages, total_count }` で統一（`per_page` は返さない＝フロント未使用）
 
 ### Ransack
 

--- a/app/controllers/api/v1/areas_controller.rb
+++ b/app/controllers/api/v1/areas_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class AreasController < BaseController
       def index
-        render_full_collection(Area.order(:id), serializer: AreaSerializer)
+        render_full_collection(Area.order(:id), serializer: AreaSerializer, root: :areas)
       end
     end
   end

--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -12,7 +12,7 @@ module Api
         token = JwtService.encode(user_id: user.id, provider: provider)
 
         render json: {
-          jwt: token,
+          token: token,
           user: serialize_user_payload(user)
         }
       rescue OauthUserInfoFetcher::FetchError => e

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -59,34 +59,33 @@ module Api
         scope.page(params[:page]).per(per_page)
       end
 
-      def render_collection(records, serializer:, serializer_params: {})
+      def render_collection(records, serializer:, root: :data, serializer_params: {})
         serialized = serializer.new(records.to_a, params: serializer_params).serializable_hash
         render json: {
-          data: flatten_serialized(serialized[:data]),
+          root => flatten_serialized(serialized[:data]),
           meta: pagination_meta(records)
         }
       end
 
-      def render_resource(record, serializer:, serializer_params: {})
+      def render_resource(record, serializer:, root: :data, serializer_params: {})
         serialized = serializer.new(record, params: serializer_params).serializable_hash
-        render json: { data: flatten_serialized(serialized[:data]) }
+        render json: { root => flatten_serialized(serialized[:data]) }
       end
 
       # ジャンル / エリアのような件数の少ない参照リストはページネーションせず全件返す。
       # フロントの絞り込み選択肢が欠落しないよう meta は付けない。
       # NOTE: 全件をメモリにロードするため、件数の少ない参照リスト専用。
       #       大量データを持つテーブルには使わないこと（一覧は render_collection を使う）。
-      def render_full_collection(records, serializer:, serializer_params: {})
+      def render_full_collection(records, serializer:, root: :data, serializer_params: {})
         serialized = serializer.new(records.to_a, params: serializer_params).serializable_hash
-        render json: { data: flatten_serialized(serialized[:data]) }
+        render json: { root => flatten_serialized(serialized[:data]) }
       end
 
       def pagination_meta(records)
         {
           current_page: records.current_page,
           total_pages: records.total_pages,
-          total_count: records.total_count,
-          per_page: records.limit_value
+          total_count: records.total_count
         }
       end
 

--- a/app/controllers/api/v1/current_user_controller.rb
+++ b/app/controllers/api/v1/current_user_controller.rb
@@ -4,7 +4,7 @@ module Api
       before_action :require_authentication!
 
       def show
-        render json: { data: serialize_user_payload(current_user) }
+        render json: { user: serialize_user_payload(current_user) }
       end
     end
   end

--- a/app/controllers/api/v1/genres_controller.rb
+++ b/app/controllers/api/v1/genres_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class GenresController < BaseController
       def index
-        render_full_collection(Genre.order(:id), serializer: GenreSerializer)
+        render_full_collection(Genre.order(:id), serializer: GenreSerializer, root: :genres)
       end
     end
   end

--- a/app/controllers/api/v1/greentea_likes_controller.rb
+++ b/app/controllers/api/v1/greentea_likes_controller.rb
@@ -4,7 +4,7 @@ module Api
       before_action :require_authentication!
 
       def index
-        scope = current_user.greenteas.order('greentea_likes.created_at DESC')
+        scope = current_user.greenteas.includes(:genres).order('greentea_likes.created_at DESC')
         paginated = paginate(scope).load
         ids = paginated.map(&:id)
         like_counts = GreenteaLike.where(greentea_id: ids).group(:greentea_id).count

--- a/app/controllers/api/v1/greenteas_controller.rb
+++ b/app/controllers/api/v1/greenteas_controller.rb
@@ -2,41 +2,37 @@ module Api
   module V1
     class GreenteasController < BaseController
       def index
-        scope = Greentea.ransack(params[:q]).result(distinct: true).order(:id)
+        scope = Greentea.includes(:genres).ransack(params[:q]).result(distinct: true).order(:id)
         paginated = paginate(scope).load
         ids = paginated.map(&:id)
         like_counts = GreenteaLike.where(greentea_id: ids).group(:greentea_id).count
-        liked_ids = liked_ids_for(ids)
 
         render_collection(
           paginated,
           serializer: GreenteaSerializer,
-          serializer_params: { like_counts: like_counts, liked_ids: liked_ids }
+          root: :greenteas,
+          serializer_params: { like_counts: like_counts }
         )
       end
 
       def show
-        greentea = Greentea.includes(:genres).find(params[:id])
+        greentea = Greentea.includes(:genres, greenteacomments: :user).find(params[:id])
         nearby_temples = nearby_temples_for(greentea)
 
         render_resource(
           greentea,
           serializer: GreenteaDetailSerializer,
+          root: :greentea,
           serializer_params: {
-            like_count: greentea.greentea_likes.size,
+            likes_count: greentea.greentea_likes.size,
             nearby_temples: nearby_temples,
-            liked_by_current_user: liked_by_current_user?(greentea.id)
+            liked_by_current_user: liked_by_current_user?(greentea.id),
+            current_user_id: current_user&.id
           }
         )
       end
 
       private
-
-      def liked_ids_for(ids)
-        return [] unless current_user && ids.any?
-
-        current_user.greentea_likes.where(greentea_id: ids).pluck(:greentea_id).to_set
-      end
 
       def liked_by_current_user?(greentea_id)
         return false unless current_user

--- a/app/controllers/api/v1/temple_likes_controller.rb
+++ b/app/controllers/api/v1/temple_likes_controller.rb
@@ -4,7 +4,7 @@ module Api
       before_action :require_authentication!
 
       def index
-        scope = current_user.temples.order('temple_likes.created_at DESC')
+        scope = current_user.temples.includes(:areas).order('temple_likes.created_at DESC')
         paginated = paginate(scope).load
         ids = paginated.map(&:id)
         like_counts = TempleLike.where(temple_id: ids).group(:temple_id).count

--- a/app/controllers/api/v1/temples_controller.rb
+++ b/app/controllers/api/v1/temples_controller.rb
@@ -2,41 +2,37 @@ module Api
   module V1
     class TemplesController < BaseController
       def index
-        scope = Temple.ransack(params[:q]).result(distinct: true).order(:id)
+        scope = Temple.includes(:areas).ransack(params[:q]).result(distinct: true).order(:id)
         paginated = paginate(scope).load
         ids = paginated.map(&:id)
         like_counts = TempleLike.where(temple_id: ids).group(:temple_id).count
-        liked_ids = liked_ids_for(ids)
 
         render_collection(
           paginated,
           serializer: TempleSerializer,
-          serializer_params: { like_counts: like_counts, liked_ids: liked_ids }
+          root: :temples,
+          serializer_params: { like_counts: like_counts }
         )
       end
 
       def show
-        temple = Temple.includes(:areas).find(params[:id])
+        temple = Temple.includes(:areas, templecomments: :user).find(params[:id])
         nearby_greenteas = nearby_greenteas_for(temple)
 
         render_resource(
           temple,
           serializer: TempleDetailSerializer,
+          root: :temple,
           serializer_params: {
-            like_count: temple.temple_likes.size,
+            likes_count: temple.temple_likes.size,
             nearby_greenteas: nearby_greenteas,
-            liked_by_current_user: liked_by_current_user?(temple.id)
+            liked_by_current_user: liked_by_current_user?(temple.id),
+            current_user_id: current_user&.id
           }
         )
       end
 
       private
-
-      def liked_ids_for(ids)
-        return [] unless current_user && ids.any?
-
-        current_user.temple_likes.where(temple_id: ids).pluck(:temple_id).to_set
-      end
 
       def liked_by_current_user?(temple_id)
         return false unless current_user

--- a/app/serializers/api/v1/greentea_detail_serializer.rb
+++ b/app/serializers/api/v1/greentea_detail_serializer.rb
@@ -23,7 +23,7 @@ module Api
       end
 
       attribute :comments do |obj, params|
-        obj.greenteacomments.map do |comment|
+        obj.greenteacomments.sort_by(&:created_at).map do |comment|
           {
             id: comment.id,
             body: comment.body,

--- a/app/serializers/api/v1/greentea_detail_serializer.rb
+++ b/app/serializers/api/v1/greentea_detail_serializer.rb
@@ -6,8 +6,12 @@ module Api
       attributes :name, :description, :address, :access, :business_hours,
                  :holiday, :phone_number, :homepage, :latitude, :longitude, :img
 
-      attribute :like_count do |obj, params|
-        params[:like_count] || obj.greentea_likes.size
+      attribute :closed do |obj|
+        obj.closed == 1
+      end
+
+      attribute :likes_count do |obj, params|
+        params[:likes_count] || obj.greentea_likes.size
       end
 
       attribute :liked_by_current_user do |_obj, params|
@@ -16,6 +20,19 @@ module Api
 
       attribute :genres do |obj|
         obj.genres.map { |g| { id: g.id, name: g.name } }
+      end
+
+      attribute :comments do |obj, params|
+        obj.greenteacomments.map do |comment|
+          {
+            id: comment.id,
+            body: comment.body,
+            created_at: comment.created_at,
+            owned_by_current_user: params[:current_user_id].present? &&
+              comment.user_id == params[:current_user_id],
+            user: { id: comment.user_id, name: comment.user&.name }
+          }
+        end
       end
 
       attribute :nearby_temples do |obj, params|

--- a/app/serializers/api/v1/greentea_serializer.rb
+++ b/app/serializers/api/v1/greentea_serializer.rb
@@ -3,15 +3,19 @@ module Api
     class GreenteaSerializer
       include JSONAPI::Serializer
 
-      attributes :name, :address, :access, :business_hours, :holiday,
-                 :latitude, :longitude, :img
+      attributes :name, :description, :address, :access, :phone_number,
+                 :business_hours, :holiday, :homepage, :latitude, :longitude, :img
 
-      attribute :like_count do |obj, params|
-        params[:like_counts]&.fetch(obj.id, 0) || 0
+      attribute :closed do |obj|
+        obj.closed == 1
       end
 
-      attribute :liked_by_current_user do |obj, params|
-        params[:liked_ids]&.include?(obj.id) || false
+      attribute :genres do |obj|
+        obj.genres.map { |g| { id: g.id, name: g.name } }
+      end
+
+      attribute :likes_count do |obj, params|
+        params[:like_counts]&.fetch(obj.id, 0) || 0
       end
     end
   end

--- a/app/serializers/api/v1/temple_detail_serializer.rb
+++ b/app/serializers/api/v1/temple_detail_serializer.rb
@@ -19,7 +19,7 @@ module Api
       end
 
       attribute :comments do |obj, params|
-        obj.templecomments.map do |comment|
+        obj.templecomments.sort_by(&:created_at).map do |comment|
           {
             id: comment.id,
             body: comment.body,

--- a/app/serializers/api/v1/temple_detail_serializer.rb
+++ b/app/serializers/api/v1/temple_detail_serializer.rb
@@ -6,8 +6,8 @@ module Api
       attributes :name, :description, :address, :access, :business_hours,
                  :holiday, :phone_number, :homepage, :latitude, :longitude, :img
 
-      attribute :like_count do |obj, params|
-        params[:like_count] || obj.temple_likes.size
+      attribute :likes_count do |obj, params|
+        params[:likes_count] || obj.temple_likes.size
       end
 
       attribute :liked_by_current_user do |_obj, params|
@@ -16,6 +16,19 @@ module Api
 
       attribute :areas do |obj|
         obj.areas.map { |a| { id: a.id, name: a.name } }
+      end
+
+      attribute :comments do |obj, params|
+        obj.templecomments.map do |comment|
+          {
+            id: comment.id,
+            body: comment.body,
+            created_at: comment.created_at,
+            owned_by_current_user: params[:current_user_id].present? &&
+              comment.user_id == params[:current_user_id],
+            user: { id: comment.user_id, name: comment.user&.name }
+          }
+        end
       end
 
       attribute :nearby_greenteas do |obj, params|

--- a/app/serializers/api/v1/temple_serializer.rb
+++ b/app/serializers/api/v1/temple_serializer.rb
@@ -3,15 +3,15 @@ module Api
     class TempleSerializer
       include JSONAPI::Serializer
 
-      attributes :name, :address, :access, :business_hours, :holiday,
-                 :latitude, :longitude, :img
+      attributes :name, :description, :address, :access, :phone_number,
+                 :business_hours, :holiday, :homepage, :latitude, :longitude, :img
 
-      attribute :like_count do |obj, params|
-        params[:like_counts]&.fetch(obj.id, 0) || 0
+      attribute :areas do |obj|
+        obj.areas.map { |a| { id: a.id, name: a.name } }
       end
 
-      attribute :liked_by_current_user do |obj, params|
-        params[:liked_ids]&.include?(obj.id) || false
+      attribute :likes_count do |obj, params|
+        params[:like_counts]&.fetch(obj.id, 0) || 0
       end
     end
   end

--- a/scripts/verify-api-contract.sh
+++ b/scripts/verify-api-contract.sh
@@ -225,7 +225,7 @@ check() {
 
   local live exp missing extra
   live="$(echo "$body" | keypaths)"
-  exp="$(expected_keypaths "$expkey")"
+  exp="$(expected_keypaths "$expkey" | sort -u)"
 
   missing="$(comm -23 <(echo "$exp") <(echo "$live"))"
   extra="$(comm -13 <(echo "$exp") <(echo "$live"))"

--- a/scripts/verify-api-contract.sh
+++ b/scripts/verify-api-contract.sh
@@ -192,6 +192,7 @@ EOF
     cat <<'EOF'
 user.id
 user.name
+user.role
 EOF
     ;;
   esac

--- a/scripts/verify-api-contract.sh
+++ b/scripts/verify-api-contract.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+#
+# 実 Rails API のレスポンス構造を、フロント (matcha-to-jinja) の契約正本である
+# fixtures から生成したキーパス集合と突き合わせて、ドリフトを検出する。
+#
+# 自己完結版: 期待キーパスをスクリプト内に埋め込んでいるため、matcha-to-jinja の
+#            fixtures をディスクから読まない。greentea_temple 単体で動く。
+#            （埋め込み値は matcha-to-jinja の
+#             src/lib/api/__tests__/fixtures/*.json から生成した正本）
+#
+# 比較方法:
+#   各レスポンスを「値を無視したキーパス集合」に正規化し、期待値と diff する。
+#   - MISSING : 期待値にあって実レスポンスに無いキー（フィールド欠落 / 命名ズレ）
+#               ※ 配列が空のときは中身のキーパスが出ないため誤検知し得る → データを入れて確認
+#   - EXTRA   : 実レスポンスにあって期待値に無いキー（Rails が余分に返している）
+#
+# jq idiom 注意:
+#   paths(scalars) は値が false / null のリーフを黙って落とす（select が値自体を
+#   条件と解釈するため）。closed / owned_by_current_user 等の false 値が消えて
+#   検出漏れになるので、ここでは type ベースの正規化を使う。
+#
+# 使い方:
+#   bin/rails server -p 3001            # 別ターミナルで Rails を起動
+#   ./scripts/verify-api-contract.sh
+#
+# 環境変数:
+#   BASE       既定 http://localhost:3001/api/v1
+#   JWT        指定すると認証必須エンドポイント (current_user) も検証
+#   GID/TID    詳細で叩く greentea_id / temple_id（既定 1 / 1）
+#   LAT/LNG/RADIUS  nearby 用（既定 35.0036 / 135.7752 / 1.5[km]）
+
+set -uo pipefail
+
+BASE="${BASE:-http://localhost:3001/api/v1}"
+GID="${GID:-1}"
+TID="${TID:-1}"
+LAT="${LAT:-35.0036}"
+LNG="${LNG:-135.7752}"
+RADIUS="${RADIUS:-1.5}"
+
+command -v jq >/dev/null || { echo "jq が必要です (apt install jq / brew install jq)"; exit 1; }
+
+pass=0; drift=0; fail=0
+
+# JSON を「値を無視した正規化キーパス集合」に変換。
+# paths(scalars) の false/null 脱落バグを避け、type ベースで葉を選ぶ。
+# 配列インデックスは [] に畳む。
+keypaths() {
+  jq -r 'paths(type!="object" and type!="array")
+         | map(if type=="number" then "[]" else tostring end)
+         | join(".")' | sort -u
+}
+
+# 各エンドポイントの期待キーパス（フロント fixtures から生成した正本）
+expected_keypaths() {
+  case "$1" in
+  greenteas.list)
+    cat <<'EOF'
+greenteas.[].access
+greenteas.[].address
+greenteas.[].business_hours
+greenteas.[].closed
+greenteas.[].description
+greenteas.[].genres.[].id
+greenteas.[].genres.[].name
+greenteas.[].holiday
+greenteas.[].homepage
+greenteas.[].id
+greenteas.[].img
+greenteas.[].latitude
+greenteas.[].likes_count
+greenteas.[].longitude
+greenteas.[].name
+greenteas.[].phone_number
+meta.current_page
+meta.total_count
+meta.total_pages
+EOF
+    ;;
+  greenteas.show)
+    cat <<'EOF'
+greentea.access
+greentea.address
+greentea.business_hours
+greentea.closed
+greentea.comments.[].body
+greentea.comments.[].created_at
+greentea.comments.[].id
+greentea.comments.[].owned_by_current_user
+greentea.comments.[].user.id
+greentea.comments.[].user.name
+greentea.description
+greentea.genres.[].id
+greentea.genres.[].name
+greentea.holiday
+greentea.homepage
+greentea.id
+greentea.img
+greentea.latitude
+greentea.liked_by_current_user
+greentea.likes_count
+greentea.longitude
+greentea.name
+greentea.nearby_temples.[].distance_meters
+greentea.nearby_temples.[].id
+greentea.nearby_temples.[].latitude
+greentea.nearby_temples.[].longitude
+greentea.nearby_temples.[].name
+greentea.phone_number
+EOF
+    ;;
+  temples.list)
+    cat <<'EOF'
+meta.current_page
+meta.total_count
+meta.total_pages
+temples.[].access
+temples.[].address
+temples.[].areas.[].id
+temples.[].areas.[].name
+temples.[].business_hours
+temples.[].description
+temples.[].holiday
+temples.[].homepage
+temples.[].id
+temples.[].img
+temples.[].latitude
+temples.[].likes_count
+temples.[].longitude
+temples.[].name
+temples.[].phone_number
+EOF
+    ;;
+  temples.show)
+    cat <<'EOF'
+temple.access
+temple.address
+temple.areas.[].id
+temple.areas.[].name
+temple.business_hours
+temple.comments.[].body
+temple.comments.[].created_at
+temple.comments.[].id
+temple.comments.[].owned_by_current_user
+temple.comments.[].user.id
+temple.comments.[].user.name
+temple.description
+temple.holiday
+temple.homepage
+temple.id
+temple.img
+temple.latitude
+temple.liked_by_current_user
+temple.likes_count
+temple.longitude
+temple.name
+temple.nearby_greenteas.[].distance_meters
+temple.nearby_greenteas.[].id
+temple.nearby_greenteas.[].latitude
+temple.nearby_greenteas.[].longitude
+temple.nearby_greenteas.[].name
+temple.phone_number
+EOF
+    ;;
+  genres.list)
+    cat <<'EOF'
+genres.[].id
+genres.[].name
+EOF
+    ;;
+  areas.list)
+    cat <<'EOF'
+areas.[].id
+areas.[].name
+EOF
+    ;;
+  nearby)
+    cat <<'EOF'
+greenteas.[].distance_meters
+greenteas.[].id
+greenteas.[].latitude
+greenteas.[].longitude
+greenteas.[].name
+temples.[].distance_meters
+temples.[].id
+temples.[].latitude
+temples.[].longitude
+temples.[].name
+EOF
+    ;;
+  current_user)
+    cat <<'EOF'
+user.id
+user.name
+EOF
+    ;;
+  esac
+}
+
+# $1=表示名 $2=method $3=path $4=expectedキー $5=auth(1なら要JWT)
+check() {
+  local name="$1" method="$2" path="$3" expkey="$4" need_auth="${5:-0}"
+
+  if [[ "$need_auth" == "1" && -z "${JWT:-}" ]]; then
+    printf "  SKIP  %-26s (JWT 未設定)\n" "$name"
+    return
+  fi
+
+  local hdr=(); [[ -n "${JWT:-}" ]] && hdr=(-H "Authorization: Bearer $JWT")
+
+  local body code
+  body="$(curl -sS -m 15 -X "$method" "${hdr[@]}" -w $'\n%{http_code}' "$BASE$path" 2>/dev/null)"
+  code="${body##*$'\n'}"
+  body="${body%$'\n'*}"
+
+  if [[ "$code" != "200" ]]; then
+    printf "  FAIL  %-26s HTTP %s\n" "$name" "$code"
+    fail=$((fail+1)); return
+  fi
+  if ! echo "$body" | jq -e . >/dev/null 2>&1; then
+    printf "  FAIL  %-26s 非JSONレスポンス\n" "$name"
+    fail=$((fail+1)); return
+  fi
+
+  local live exp missing extra
+  live="$(echo "$body" | keypaths)"
+  exp="$(expected_keypaths "$expkey")"
+
+  missing="$(comm -23 <(echo "$exp") <(echo "$live"))"
+  extra="$(comm -13 <(echo "$exp") <(echo "$live"))"
+
+  if [[ -z "$missing" && -z "$extra" ]]; then
+    printf "  PASS  %-26s\n" "$name"
+    pass=$((pass+1))
+  else
+    printf "  DRIFT %-26s\n" "$name"
+    [[ -n "$missing" ]] && echo "$missing" | sed 's/^/          - MISSING /'
+    [[ -n "$extra"   ]] && echo "$extra"   | sed 's/^/          + EXTRA   /'
+    drift=$((drift+1))
+  fi
+}
+
+echo "BASE = $BASE"
+echo
+echo "[読み取り系]"
+check "GET /greenteas"      GET "/greenteas"      greenteas.list
+check "GET /greenteas/:id"  GET "/greenteas/$GID" greenteas.show
+check "GET /temples"        GET "/temples"        temples.list
+check "GET /temples/:id"    GET "/temples/$TID"   temples.show
+check "GET /genres"         GET "/genres"         genres.list
+check "GET /areas"          GET "/areas"          areas.list
+check "GET /nearby"         GET "/nearby?lat=$LAT&lng=$LNG&radius=$RADIUS" nearby
+
+echo
+echo "[認証系] (JWT 設定時のみ)"
+check "GET /current_user"   GET "/current_user"   current_user 1
+
+echo
+echo "----------------------------------------"
+echo "PASS=$pass  DRIFT=$drift  FAIL=$fail"
+echo
+echo "注意:"
+echo " - DRIFT の MISSING は配列が空（コメント/いいね0件等）でも出ます。データを入れて再確認を。"
+echo " - 書き込み系 (likes/comments POST·DELETE, POST /auth/:provider) は副作用があるため自動検証から除外。"
+
+[[ $fail -gt 0 || $drift -gt 0 ]] && exit 1 || exit 0

--- a/spec/requests/api/v1/areas_spec.rb
+++ b/spec/requests/api/v1/areas_spec.rb
@@ -9,15 +9,15 @@ RSpec.describe 'Api::V1::Areas', type: :request do
 
       expect(response).to have_http_status(:ok)
       json = response.parsed_body
-      expect(json['data'].size).to eq(2)
-      expect(json['data'].first).to include('id', 'name')
-      expect(json['data'].first['id']).to be_a(Integer)
+      expect(json['areas'].size).to eq(2)
+      expect(json['areas'].first).to include('id', 'name')
+      expect(json['areas'].first['id']).to be_a(Integer)
     end
 
     it 'orders areas by id ascending' do
       get '/api/v1/areas'
 
-      ids = response.parsed_body['data'].map { |a| a['id'] }
+      ids = response.parsed_body['areas'].map { |a| a['id'] }
       expect(ids).to eq(ids.sort)
     end
 
@@ -28,8 +28,8 @@ RSpec.describe 'Api::V1::Areas', type: :request do
       get '/api/v1/areas'
 
       json = response.parsed_body
-      expect(json['data'].size).to be > 15
-      expect(json['data'].size).to eq(Area.count)
+      expect(json['areas'].size).to be > 15
+      expect(json['areas'].size).to eq(Area.count)
       expect(json).not_to have_key('meta')
     end
   end

--- a/spec/requests/api/v1/auth_spec.rb
+++ b/spec/requests/api/v1/auth_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Api::V1::Auth', type: :request do
 
         expect(response).to have_http_status(:ok)
         body = response.parsed_body
-        expect(body['jwt']).to be_a(String).and be_present
+        expect(body['token']).to be_a(String).and be_present
         expect(body['user']).to include('id', 'name', 'role')
         expect(body['user']['name']).to eq('もちもち抹茶')
 
@@ -41,14 +41,14 @@ RSpec.describe 'Api::V1::Auth', type: :request do
         expect(response).to have_http_status(:ok)
         body = response.parsed_body
         expect(body['user']['id']).to eq(existing_user.id)
-        decoded = JwtService.decode(body['jwt'])
+        decoded = JwtService.decode(body['token'])
         expect(decoded['user_id']).to eq(existing_user.id)
       end
 
       it 'embeds user_id and provider in the JWT and sets exp ~14 days ahead' do
         post '/api/v1/auth/line', params: { access_token: 'valid_line_token' }
 
-        decoded = JwtService.decode(response.parsed_body['jwt'])
+        decoded = JwtService.decode(response.parsed_body['token'])
         expect(decoded['user_id']).to eq(User.last.id)
         expect(decoded['provider']).to eq('line')
         expect(decoded['exp']).to be_within(60).of(14.days.from_now.to_i)
@@ -85,7 +85,7 @@ RSpec.describe 'Api::V1::Auth', type: :request do
 
         expect(response).to have_http_status(:ok)
         body = response.parsed_body
-        expect(body['jwt']).to be_a(String).and be_present
+        expect(body['token']).to be_a(String).and be_present
         expect(body['user']).to include('id', 'name', 'role')
         expect(body['user']['name']).to eq('matcha_san')
 

--- a/spec/requests/api/v1/current_user_spec.rb
+++ b/spec/requests/api/v1/current_user_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe 'Api::V1::CurrentUser', type: :request do
 
         expect(response).to have_http_status(:ok)
         body = response.parsed_body
-        expect(body['data']).to include(
+        expect(body['user']).to include(
           'id' => user.id,
           'name' => '抹茶ファン1号'
         )
-        expect(body['data']).to have_key('role')
+        expect(body['user']).to have_key('role')
       end
     end
 

--- a/spec/requests/api/v1/genres_spec.rb
+++ b/spec/requests/api/v1/genres_spec.rb
@@ -9,15 +9,15 @@ RSpec.describe 'Api::V1::Genres', type: :request do
 
       expect(response).to have_http_status(:ok)
       json = response.parsed_body
-      expect(json['data'].size).to eq(2)
-      expect(json['data'].first).to include('id', 'name')
-      expect(json['data'].first['id']).to be_a(Integer)
+      expect(json['genres'].size).to eq(2)
+      expect(json['genres'].first).to include('id', 'name')
+      expect(json['genres'].first['id']).to be_a(Integer)
     end
 
     it 'orders genres by id ascending' do
       get '/api/v1/genres'
 
-      ids = response.parsed_body['data'].map { |g| g['id'] }
+      ids = response.parsed_body['genres'].map { |g| g['id'] }
       expect(ids).to eq(ids.sort)
     end
 
@@ -28,8 +28,8 @@ RSpec.describe 'Api::V1::Genres', type: :request do
       get '/api/v1/genres'
 
       json = response.parsed_body
-      expect(json['data'].size).to be > 15
-      expect(json['data'].size).to eq(Genre.count)
+      expect(json['genres'].size).to be > 15
+      expect(json['genres'].size).to eq(Genre.count)
       expect(json).not_to have_key('meta')
     end
   end

--- a/spec/requests/api/v1/greentea_likes_spec.rb
+++ b/spec/requests/api/v1/greentea_likes_spec.rb
@@ -28,13 +28,12 @@ RSpec.describe 'Api::V1::GreenteaLikes', type: :request do
         json = response.parsed_body
         ids = json['data'].map { |d| d['id'] }
         expect(ids).to eq([liked.id])
-        expect(json['data'].first['liked_by_current_user']).to eq(true)
         expect(json['meta']).to include(
           'current_page' => 1,
           'total_pages' => 1,
-          'total_count' => 1,
-          'per_page' => 15
+          'total_count' => 1
         )
+        expect(json['meta']).not_to include('per_page')
       end
     end
   end

--- a/spec/requests/api/v1/greenteacomments_spec.rb
+++ b/spec/requests/api/v1/greenteacomments_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe 'Api::V1::Greenteacomments', type: :request do
 
         expect(response).to have_http_status(:ok)
         json = response.parsed_body
-        expect(json['meta']).to include('current_page', 'total_pages', 'total_count', 'per_page')
+        expect(json['meta']).to include('current_page', 'total_pages', 'total_count')
+        expect(json['meta']).not_to include('per_page')
         ids = json['data'].map { |d| d['id'] }
         expect(ids).to eq([other.id, own.id])
 

--- a/spec/requests/api/v1/greenteas_spec.rb
+++ b/spec/requests/api/v1/greenteas_spec.rb
@@ -131,6 +131,17 @@ RSpec.describe 'Api::V1::Greenteas', type: :request do
       expect(comment['owned_by_current_user']).to eq(false)
     end
 
+    it 'marks a comment as owned when the authenticated user authored it' do
+      author = create(:user)
+      create(:greenteacomment, greentea: greentea, user: author, body: '自分のコメント')
+      token = JwtService.encode({ user_id: author.id })
+
+      get "/api/v1/greenteas/#{greentea.id}", headers: { 'Authorization' => "Bearer #{token}" }
+
+      comment = response.parsed_body['greentea']['comments'].first
+      expect(comment['owned_by_current_user']).to eq(true)
+    end
+
     it 'returns liked_by_current_user=true when the authenticated user liked it' do
       user = User.create!(name: '詳細いいねユーザー')
       GreenteaLike.create!(user: user, greentea: greentea)

--- a/spec/requests/api/v1/greenteas_spec.rb
+++ b/spec/requests/api/v1/greenteas_spec.rb
@@ -4,39 +4,41 @@ RSpec.describe 'Api::V1::Greenteas', type: :request do
   describe 'GET /api/v1/greenteas' do
     let!(:greenteas) { create_list(:greentea, 3) }
 
-    it 'returns 200 with data and meta' do
+    it 'returns 200 with greenteas and meta' do
       get '/api/v1/greenteas'
 
       expect(response).to have_http_status(:ok)
       json = response.parsed_body
-      expect(json['data']).to be_an(Array)
-      expect(json['data'].size).to eq(3)
+      expect(json['greenteas']).to be_an(Array)
+      expect(json['greenteas'].size).to eq(3)
       expect(json['meta']).to include(
         'current_page' => 1,
-        'total_count' => 3,
-        'per_page' => 15
+        'total_count' => 3
       )
       expect(json['meta']['total_pages']).to eq(1)
+      expect(json['meta']).not_to include('per_page')
     end
 
     it 'returns flat snake_case spot fields' do
       get '/api/v1/greenteas'
 
-      attrs = response.parsed_body['data'].first
+      attrs = response.parsed_body['greenteas'].first
       expect(attrs).to include(
-        'id', 'name', 'address', 'access', 'business_hours', 'holiday',
-        'latitude', 'longitude', 'img', 'like_count', 'liked_by_current_user'
+        'id', 'name', 'description', 'address', 'access', 'phone_number',
+        'business_hours', 'holiday', 'homepage', 'closed', 'img',
+        'latitude', 'longitude', 'genres', 'likes_count'
       )
       expect(attrs['id']).to be_a(Integer)
-      expect(attrs['liked_by_current_user']).to eq(false)
+      # 一覧には liked_by_current_user を含めない（詳細のみ）
+      expect(attrs).not_to include('liked_by_current_user')
     end
 
     it 'paginates with page / per_page params' do
       get '/api/v1/greenteas', params: { per_page: 2, page: 2 }
 
       json = response.parsed_body
-      expect(json['data'].size).to eq(1)
-      expect(json['meta']).to include('current_page' => 2, 'total_pages' => 2, 'per_page' => 2)
+      expect(json['greenteas'].size).to eq(1)
+      expect(json['meta']).to include('current_page' => 2, 'total_pages' => 2)
     end
 
     it 'filters by q[name_cont] (Ransack allowlist)' do
@@ -44,7 +46,7 @@ RSpec.describe 'Api::V1::Greenteas', type: :request do
 
       get '/api/v1/greenteas', params: { q: { name_cont: '宇治抹茶' } }
 
-      ids = response.parsed_body['data'].map { |d| d['id'] }
+      ids = response.parsed_body['greenteas'].map { |d| d['id'] }
       expect(ids).to eq([target.id])
     end
 
@@ -55,7 +57,7 @@ RSpec.describe 'Api::V1::Greenteas', type: :request do
 
       get '/api/v1/greenteas', params: { q: { genres_id_eq: genre.id } }
 
-      ids = response.parsed_body['data'].map { |d| d['id'] }
+      ids = response.parsed_body['greenteas'].map { |d| d['id'] }
       expect(ids).to eq([target.id])
     end
 
@@ -65,7 +67,7 @@ RSpec.describe 'Api::V1::Greenteas', type: :request do
 
       get '/api/v1/greenteas', params: { q: { name_or_description_or_address_or_access_cont: 'とろける宇治抹茶' } }
 
-      ids = response.parsed_body['data'].map { |d| d['id'] }
+      ids = response.parsed_body['greenteas'].map { |d| d['id'] }
       expect(ids).to eq([target.id])
     end
 
@@ -76,11 +78,11 @@ RSpec.describe 'Api::V1::Greenteas', type: :request do
 
       get '/api/v1/greenteas', params: { q: { greentea_genres_genre_id_eq_any: [genre.id] } }
 
-      ids = response.parsed_body['data'].map { |d| d['id'] }
+      ids = response.parsed_body['greenteas'].map { |d| d['id'] }
       expect(ids).to eq([target.id])
     end
 
-    it 'returns like_count aggregated per record' do
+    it 'returns likes_count aggregated per record' do
       liked = greenteas.first
       user_a = create(:user)
       user_b = create(:user)
@@ -89,22 +91,15 @@ RSpec.describe 'Api::V1::Greenteas', type: :request do
 
       get '/api/v1/greenteas'
 
-      payload = response.parsed_body['data'].find { |d| d['id'] == liked.id }
-      expect(payload['like_count']).to eq(2)
+      payload = response.parsed_body['greenteas'].find { |d| d['id'] == liked.id }
+      expect(payload['likes_count']).to eq(2)
     end
 
-    it 'reflects liked_by_current_user when authenticated' do
-      user = User.create!(name: 'いいね回帰テスト')
-      liked = greenteas.first
-      GreenteaLike.create!(user: user, greentea: liked)
-      token = JwtService.encode({ user_id: user.id })
+    it 'normalizes closed to a boolean' do
+      get '/api/v1/greenteas'
 
-      get '/api/v1/greenteas', headers: { 'Authorization' => "Bearer #{token}" }
-
-      liked_payload = response.parsed_body['data'].find { |d| d['id'] == liked.id }
-      unliked_payload = response.parsed_body['data'].find { |d| d['id'] != liked.id }
-      expect(liked_payload['liked_by_current_user']).to eq(true)
-      expect(unliked_payload['liked_by_current_user']).to eq(false)
+      closed_values = response.parsed_body['greenteas'].map { |d| d['closed'] }
+      expect(closed_values).to all(be_in([true, false]))
     end
   end
 
@@ -115,13 +110,25 @@ RSpec.describe 'Api::V1::Greenteas', type: :request do
       get "/api/v1/greenteas/#{greentea.id}"
 
       expect(response).to have_http_status(:ok)
-      attrs = response.parsed_body['data']
+      attrs = response.parsed_body['greentea']
       expect(attrs).to include(
         'id', 'name', 'description', 'address', 'access', 'business_hours',
-        'holiday', 'phone_number', 'homepage', 'latitude', 'longitude', 'img',
-        'like_count', 'liked_by_current_user', 'genres', 'nearby_temples'
+        'holiday', 'phone_number', 'homepage', 'closed', 'latitude', 'longitude', 'img',
+        'likes_count', 'liked_by_current_user', 'genres', 'nearby_temples', 'comments'
       )
       expect(attrs['id']).to eq(greentea.id)
+    end
+
+    it 'includes comments with author and ownership flag' do
+      author = create(:user)
+      create(:greenteacomment, greentea: greentea, user: author, body: '美味しかった')
+
+      get "/api/v1/greenteas/#{greentea.id}"
+
+      comment = response.parsed_body['greentea']['comments'].first
+      expect(comment).to include('id', 'body', 'created_at', 'owned_by_current_user')
+      expect(comment['user']).to include('id' => author.id, 'name' => author.name)
+      expect(comment['owned_by_current_user']).to eq(false)
     end
 
     it 'returns liked_by_current_user=true when the authenticated user liked it' do
@@ -131,7 +138,7 @@ RSpec.describe 'Api::V1::Greenteas', type: :request do
 
       get "/api/v1/greenteas/#{greentea.id}", headers: { 'Authorization' => "Bearer #{token}" }
 
-      expect(response.parsed_body['data']['liked_by_current_user']).to eq(true)
+      expect(response.parsed_body['greentea']['liked_by_current_user']).to eq(true)
     end
 
     it 'includes nearby_temples sorted by distance ascending with meter values' do
@@ -140,7 +147,7 @@ RSpec.describe 'Api::V1::Greenteas', type: :request do
 
       get "/api/v1/greenteas/#{greentea.id}"
 
-      nearby = response.parsed_body['data']['nearby_temples']
+      nearby = response.parsed_body['greentea']['nearby_temples']
       expect(nearby.map { |t| t['id'] }).to eq([near.id, mid.id])
       nearby.each do |t|
         expect(t).to include('id', 'name', 'latitude', 'longitude', 'distance_meters')

--- a/spec/requests/api/v1/routes_spec.rb
+++ b/spec/requests/api/v1/routes_spec.rb
@@ -47,8 +47,7 @@ RSpec.describe 'Api::V1::Routes', type: :request do
         expect(json['meta']).to include(
           'current_page' => 1,
           'total_pages' => 1,
-          'total_count' => 1,
-          'per_page' => 15
+          'total_count' => 1
         )
       end
     end

--- a/spec/requests/api/v1/temple_likes_spec.rb
+++ b/spec/requests/api/v1/temple_likes_spec.rb
@@ -28,13 +28,12 @@ RSpec.describe 'Api::V1::TempleLikes', type: :request do
         json = response.parsed_body
         ids = json['data'].map { |d| d['id'] }
         expect(ids).to eq([liked.id])
-        expect(json['data'].first['liked_by_current_user']).to eq(true)
         expect(json['meta']).to include(
           'current_page' => 1,
           'total_pages' => 1,
-          'total_count' => 1,
-          'per_page' => 15
+          'total_count' => 1
         )
+        expect(json['meta']).not_to include('per_page')
       end
     end
   end

--- a/spec/requests/api/v1/templecomments_spec.rb
+++ b/spec/requests/api/v1/templecomments_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe 'Api::V1::Templecomments', type: :request do
 
         expect(response).to have_http_status(:ok)
         json = response.parsed_body
-        expect(json['meta']).to include('current_page', 'total_pages', 'total_count', 'per_page')
+        expect(json['meta']).to include('current_page', 'total_pages', 'total_count')
+        expect(json['meta']).not_to include('per_page')
         ids = json['data'].map { |d| d['id'] }
         expect(ids).to eq([other.id, own.id])
 

--- a/spec/requests/api/v1/temples_spec.rb
+++ b/spec/requests/api/v1/temples_spec.rb
@@ -4,27 +4,30 @@ RSpec.describe 'Api::V1::Temples', type: :request do
   describe 'GET /api/v1/temples' do
     let!(:temples) { create_list(:temple, 3) }
 
-    it 'returns 200 with data and meta' do
+    it 'returns 200 with temples and meta' do
       get '/api/v1/temples'
 
       expect(response).to have_http_status(:ok)
       json = response.parsed_body
-      expect(json['data'].size).to eq(3)
+      expect(json['temples'].size).to eq(3)
       expect(json['meta']).to include(
         'current_page' => 1,
-        'total_count' => 3,
-        'per_page' => 15
+        'total_count' => 3
       )
+      expect(json['meta']).not_to include('per_page')
     end
 
     it 'returns flat snake_case spot fields' do
       get '/api/v1/temples'
 
-      attrs = response.parsed_body['data'].first
+      attrs = response.parsed_body['temples'].first
       expect(attrs).to include(
-        'id', 'name', 'address', 'access', 'business_hours', 'holiday',
-        'latitude', 'longitude', 'img', 'like_count', 'liked_by_current_user'
+        'id', 'name', 'description', 'address', 'access', 'phone_number',
+        'business_hours', 'holiday', 'homepage', 'img',
+        'latitude', 'longitude', 'areas', 'likes_count'
       )
+      # 一覧には liked_by_current_user を含めない（詳細のみ）。temple に closed は無い
+      expect(attrs).not_to include('liked_by_current_user', 'closed')
     end
 
     it 'filters by q[areas_id_eq]' do
@@ -34,7 +37,7 @@ RSpec.describe 'Api::V1::Temples', type: :request do
 
       get '/api/v1/temples', params: { q: { areas_id_eq: area.id } }
 
-      ids = response.parsed_body['data'].map { |d| d['id'] }
+      ids = response.parsed_body['temples'].map { |d| d['id'] }
       expect(ids).to eq([target.id])
     end
 
@@ -44,7 +47,7 @@ RSpec.describe 'Api::V1::Temples', type: :request do
 
       get '/api/v1/temples', params: { q: { name_or_description_or_address_or_access_cont: '紅葉の名所' } }
 
-      ids = response.parsed_body['data'].map { |d| d['id'] }
+      ids = response.parsed_body['temples'].map { |d| d['id'] }
       expect(ids).to eq([target.id])
     end
 
@@ -55,22 +58,19 @@ RSpec.describe 'Api::V1::Temples', type: :request do
 
       get '/api/v1/temples', params: { q: { temple_areas_area_id_eq_any: [area.id] } }
 
-      ids = response.parsed_body['data'].map { |d| d['id'] }
+      ids = response.parsed_body['temples'].map { |d| d['id'] }
       expect(ids).to eq([target.id])
     end
 
-    it 'reflects liked_by_current_user when authenticated' do
-      user = User.create!(name: '神社いいね回帰テスト')
+    it 'returns likes_count aggregated per record' do
       liked = temples.first
-      TempleLike.create!(user: user, temple: liked)
-      token = JwtService.encode({ user_id: user.id })
+      TempleLike.create!(user: create(:user), temple: liked)
+      TempleLike.create!(user: create(:user), temple: liked)
 
-      get '/api/v1/temples', headers: { 'Authorization' => "Bearer #{token}" }
+      get '/api/v1/temples'
 
-      liked_payload = response.parsed_body['data'].find { |d| d['id'] == liked.id }
-      unliked_payload = response.parsed_body['data'].find { |d| d['id'] != liked.id }
-      expect(liked_payload['liked_by_current_user']).to eq(true)
-      expect(unliked_payload['liked_by_current_user']).to eq(false)
+      payload = response.parsed_body['temples'].find { |d| d['id'] == liked.id }
+      expect(payload['likes_count']).to eq(2)
     end
   end
 
@@ -83,11 +83,11 @@ RSpec.describe 'Api::V1::Temples', type: :request do
       get "/api/v1/temples/#{temple.id}"
 
       expect(response).to have_http_status(:ok)
-      attrs = response.parsed_body['data']
+      attrs = response.parsed_body['temple']
       expect(attrs).to include(
         'id', 'name', 'description', 'address', 'access', 'business_hours',
         'holiday', 'phone_number', 'homepage', 'latitude', 'longitude', 'img',
-        'like_count', 'liked_by_current_user', 'areas', 'nearby_greenteas'
+        'likes_count', 'liked_by_current_user', 'areas', 'nearby_greenteas', 'comments'
       )
       expect(attrs['nearby_greenteas'].map { |g| g['id'] }).to include(near.id)
       attrs['nearby_greenteas'].each do |g|
@@ -99,6 +99,18 @@ RSpec.describe 'Api::V1::Temples', type: :request do
       expected = (origin.distance_to(Geokit::LatLng.new(near.latitude, near.longitude), units: :kms) * 1000).round
       near_payload = attrs['nearby_greenteas'].find { |g| g['id'] == near.id }
       expect(near_payload['distance_meters']).to be_within(2).of(expected)
+    end
+
+    it 'includes comments with author and ownership flag' do
+      author = create(:user)
+      create(:templecomment, temple: temple, user: author, body: '良い神社でした')
+
+      get "/api/v1/temples/#{temple.id}"
+
+      comment = response.parsed_body['temple']['comments'].first
+      expect(comment).to include('id', 'body', 'created_at', 'owned_by_current_user')
+      expect(comment['user']).to include('id' => author.id, 'name' => author.name)
+      expect(comment['owned_by_current_user']).to eq(false)
     end
 
     it 'returns 404 with error body for missing id' do
@@ -115,7 +127,7 @@ RSpec.describe 'Api::V1::Temples', type: :request do
 
       get "/api/v1/temples/#{temple.id}", headers: { 'Authorization' => "Bearer #{token}" }
 
-      expect(response.parsed_body['data']['liked_by_current_user']).to eq(true)
+      expect(response.parsed_body['temple']['liked_by_current_user']).to eq(true)
     end
   end
 end

--- a/spec/requests/api/v1/temples_spec.rb
+++ b/spec/requests/api/v1/temples_spec.rb
@@ -113,6 +113,17 @@ RSpec.describe 'Api::V1::Temples', type: :request do
       expect(comment['owned_by_current_user']).to eq(false)
     end
 
+    it 'marks a comment as owned when the authenticated user authored it' do
+      author = create(:user)
+      create(:templecomment, temple: temple, user: author, body: '自分のコメント')
+      token = JwtService.encode({ user_id: author.id })
+
+      get "/api/v1/temples/#{temple.id}", headers: { 'Authorization' => "Bearer #{token}" }
+
+      comment = response.parsed_body['temple']['comments'].first
+      expect(comment['owned_by_current_user']).to eq(true)
+    end
+
     it 'returns 404 with error body for missing id' do
       get '/api/v1/temples/999999'
 

--- a/spec/requests/api/v1/temples_spec.rb
+++ b/spec/requests/api/v1/temples_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'Api::V1::Temples', type: :request do
       expect(json['temples'].size).to eq(3)
       expect(json['meta']).to include(
         'current_page' => 1,
+        'total_pages' => 1,
         'total_count' => 3
       )
       expect(json['meta']).not_to include('per_page')


### PR DESCRIPTION
## 概要

フロントエンド（matcha-to-jinja）の契約正本 `src/lib/api/__tests__/fixtures/*.json` と、実 Rails API のレスポンスを突き合わせて検出したドリフトを解消します。

実 API 連携の前に「Rails の実レスポンスがフロントの期待形と一致するか」を自動検証できるよう、自己完結スクリプト `scripts/verify-api-contract.sh` を追加し、**`PASS=8`（読み取り7 + current_user）DRIFT=0** になる状態にしました。

> 比較基準は CLAUDE.md の散文ではなく、フロントの fixtures（keypaths）です。

## 検出したドリフトと修正

### 第1層：エンベロープ（根本原因・全体に波及）
`BaseController` の `render_collection` / `render_resource` / `render_full_collection` が一律 `data` キーで包んでいたため、フロントが期待する名前付きルートキーと総ずれしていました。

- render 系に `root:` を追加し、読み取り系/認証系を `data` → `greenteas` / `greentea` / `temples` / `temple` / `genres` / `areas` / `user` に変更
- `meta` から `per_page` を削除（`current_page` / `total_pages` / `total_count` のみ）
- `AuthController` のトークンキー `jwt` → `token`
- **likes / comments / routes（#51 スコープ）は今回の対象外**のため、`root: :data` をデフォルトにして従来挙動を維持（巻き込み回避）

### 第2層：フィールドの過不足
- いいね数 `like_count` → `likes_count`（一覧・詳細）
- 一覧 serializer をフロント一覧契約に合わせてフル化
  - greentea 一覧: `closed`, `description`, `genres[]`, `homepage`, `phone_number` 追加
  - temple 一覧: `areas[]`, `description`, `homepage`, `phone_number` 追加
- 一覧から `liked_by_current_user` を削除（詳細のみ）
- 詳細 serializer に `comments[]`（`user{id,name}` 含む）を追加、greentea 詳細に `closed` を追加
- `closed` は integer カラムを boolean へ正規化（0/1 → false/true）
- N+1 回避のため index で `genres` / `areas` を `includes`、show で comments を eager load

### 決定事項（フロントと合意済み）
| 項目 | 決定 |
|---|---|
| `meta.per_page` | Rails 側で削除（フロント未使用） |
| `user.role` | 契約に残す（両側で揃える） |

## 検証結果（すべてローカル実走で確認）

| 検証 | 結果 |
|---|---|
| `scripts/verify-api-contract.sh`（JWT 込み） | **PASS=8 / DRIFT=0 / FAIL=0** |
| API request spec（`spec/requests/api/v1`） | 134 examples, **0 failures**（旧契約前提の spec を新契約へ更新） |
| 全 non-system spec | 282 examples, **0 failures**, 3 pending |
| rubocop（変更ファイル） | offenses なし |

## 補足

- `scripts/verify-api-contract.sh` は期待キーパスを埋め込んだ自己完結版（fixtures をディスク参照しない）。`jq` の `paths(scalars)` が `false`/`null` リーフを脱落させる罠を避け、type ベースで正規化しています。
- likes / comments / routes のルートキー・レスポンス整形は #51 で対応予定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqQ2cTDxsRC282SATXsNb7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API list responses now return collections under explicit named roots (for example, `areas`, `genres`, `temples`, `greenteas`).
  * Detail responses are richer: added comments with author info and ownership flags, plus expanded place details (e.g., `closed`, `likes_count`, `areas`, `genres`).

* **Bug Fixes**
  * Standardized response fields: renamed `jwt` to `token` and `like_count` to `likes_count`.
  * Pagination metadata no longer includes `per_page`.
  * Current user endpoint now returns the user under `user` (not `data`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->