### PR TITLE
feat: 管理用 API（抹茶店・神社 CRUD / コメントモデレーション）を実装

### DIFF
--- a/app/controllers/api/v1/admin/base_controller.rb
+++ b/app/controllers/api/v1/admin/base_controller.rb
@@ -5,10 +5,21 @@ module Api
       class BaseController < Api::V1::BaseController
         before_action :require_admin!
 
+        # latitude/longitude のような NOT NULL カラムを欠いた作成・更新は DB 例外になる。
+        # 既存 Web フローの geocode（after_validation でカラムを埋める）を壊さないよう
+        # モデルへ presence 検証を足さず、API 層で 422 に変換する。
+        rescue_from ActiveRecord::NotNullViolation, with: :render_not_null_violation
+
         private
 
         def render_unprocessable(record)
           render json: { errors: record.errors.messages }, status: :unprocessable_entity
+        end
+
+        def render_not_null_violation(exception)
+          Rails.logger.info("Admin API NOT NULL violation: #{exception.message}")
+          render json: { errors: { base: ['必須項目が入力されていません'] } },
+                 status: :unprocessable_entity
         end
 
         # フロントは closed を boolean で送るが、DB は integer（0/1）で保持する。

--- a/app/controllers/api/v1/admin/base_controller.rb
+++ b/app/controllers/api/v1/admin/base_controller.rb
@@ -1,0 +1,24 @@
+module Api
+  module V1
+    module Admin
+      # 管理用 API の共通基底。全エンドポイントで admin 認可を必須にする。
+      class BaseController < Api::V1::BaseController
+        before_action :require_admin!
+
+        private
+
+        def render_unprocessable(record)
+          render json: { errors: record.errors.messages }, status: :unprocessable_entity
+        end
+
+        # フロントは closed を boolean で送るが、DB は integer（0/1）で保持する。
+        def normalize_closed(value)
+          return 1 if [true, 'true', 1, '1'].include?(value)
+          return 0 if [false, 'false', 0, '0'].include?(value)
+
+          value
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/comments_controller.rb
+++ b/app/controllers/api/v1/admin/comments_controller.rb
@@ -1,0 +1,59 @@
+module Api
+  module V1
+    module Admin
+      # 抹茶店・神社の口コミを横断して一覧するモデレーション用エンドポイント。
+      # type（greentea / temple）と spot_id で絞り込める。
+      class CommentsController < BaseController
+        def index
+          comments = collect_comments
+          paginated = Kaminari.paginate_array(comments).page(params[:page]).per(per_page)
+
+          render json: {
+            comments: paginated.map { |comment| serialize_comment(comment) },
+            meta: pagination_meta(paginated)
+          }
+        end
+
+        private
+
+        def collect_comments
+          records = []
+          records.concat(greenteacomments_scope) if include_type?('greentea')
+          records.concat(templecomments_scope) if include_type?('temple')
+          records.sort_by(&:created_at).reverse
+        end
+
+        def include_type?(type)
+          params[:type].blank? || params[:type] == type
+        end
+
+        def greenteacomments_scope
+          scope = Greenteacomment.includes(:user)
+          scope = scope.where(greentea_id: params[:spot_id]) if params[:spot_id].present?
+          scope.to_a
+        end
+
+        def templecomments_scope
+          scope = Templecomment.includes(:user)
+          scope = scope.where(temple_id: params[:spot_id]) if params[:spot_id].present?
+          scope.to_a
+        end
+
+        def serialize_comment(comment)
+          base = {
+            id: comment.id,
+            body: comment.body,
+            created_at: comment.created_at,
+            user: { id: comment.user_id, name: comment.user&.name }
+          }
+
+          if comment.is_a?(Greenteacomment)
+            base.merge(type: 'greentea', greentea_id: comment.greentea_id)
+          else
+            base.merge(type: 'temple', temple_id: comment.temple_id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/comments_controller.rb
+++ b/app/controllers/api/v1/admin/comments_controller.rb
@@ -3,24 +3,58 @@ module Api
     module Admin
       # 抹茶店・神社の口コミを横断して一覧するモデレーション用エンドポイント。
       # type（greentea / temple）と spot_id で絞り込める。
+      #
+      # 2 テーブルを跨ぐため AR の relation 1 本では取得できない。全件ロードを避けるため、
+      # 各ソースから「先頭ページ〜要求ページ末尾まで（page * per_page 件）」だけを
+      # created_at 降順で DB 側に絞って取得し、メモリ上でマージ・整列してから
+      # 該当ページ分を切り出す。total_count は各ソースの COUNT を合算する。
       class CommentsController < BaseController
         def index
-          comments = collect_comments
-          paginated = Kaminari.paginate_array(comments).page(params[:page]).per(per_page)
-
+          window = page_window
           render json: {
-            comments: paginated.map { |comment| serialize_comment(comment) },
-            meta: pagination_meta(paginated)
+            comments: window.map { |comment| serialize_comment(comment) },
+            meta: pagination_meta
           }
         end
 
         private
 
-        def collect_comments
+        def page_window
+          merged = merged_comments
+          offset = (current_page - 1) * per_page
+          merged[offset, per_page] || []
+        end
+
+        # 各ソースを page * per_page 件に絞って取得し、降順マージした上位 page * per_page 件。
+        # これにより全体の上位 N 件が必ずこの集合に含まれる（各ソースの上位 N 件の和集合）。
+        def merged_comments
+          limit = current_page * per_page
           records = []
-          records.concat(greenteacomments_scope) if include_type?('greentea')
-          records.concat(templecomments_scope) if include_type?('temple')
-          records.sort_by(&:created_at).reverse
+          records.concat(greenteacomments_scope.order(created_at: :desc).limit(limit).to_a) if include_type?('greentea')
+          records.concat(templecomments_scope.order(created_at: :desc).limit(limit).to_a) if include_type?('temple')
+          records.sort_by(&:created_at).reverse.first(limit)
+        end
+
+        def pagination_meta
+          {
+            current_page: current_page,
+            total_pages: total_count.zero? ? 0 : (total_count.to_f / per_page).ceil,
+            total_count: total_count
+          }
+        end
+
+        def total_count
+          @total_count ||= begin
+            count = 0
+            count += greenteacomments_scope.count if include_type?('greentea')
+            count += templecomments_scope.count if include_type?('temple')
+            count
+          end
+        end
+
+        def current_page
+          page = params[:page].to_i
+          page < 1 ? 1 : page
         end
 
         def include_type?(type)
@@ -30,13 +64,13 @@ module Api
         def greenteacomments_scope
           scope = Greenteacomment.includes(:user)
           scope = scope.where(greentea_id: params[:spot_id]) if params[:spot_id].present?
-          scope.to_a
+          scope
         end
 
         def templecomments_scope
           scope = Templecomment.includes(:user)
           scope = scope.where(temple_id: params[:spot_id]) if params[:spot_id].present?
-          scope.to_a
+          scope
         end
 
         def serialize_comment(comment)

--- a/app/controllers/api/v1/admin/greenteacomments_controller.rb
+++ b/app/controllers/api/v1/admin/greenteacomments_controller.rb
@@ -1,0 +1,14 @@
+module Api
+  module V1
+    module Admin
+      # admin は所有者チェックをバイパスして任意の口コミを削除できる。
+      class GreenteacommentsController < BaseController
+        def destroy
+          comment = Greenteacomment.find(params[:id])
+          comment.destroy!
+          head :no_content
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/greenteas_controller.rb
+++ b/app/controllers/api/v1/admin/greenteas_controller.rb
@@ -1,0 +1,67 @@
+module Api
+  module V1
+    module Admin
+      class GreenteasController < BaseController
+        def create
+          greentea = Greentea.new(greentea_params)
+          if greentea.save
+            render_greentea(greentea, status: :created)
+          else
+            render_unprocessable(greentea)
+          end
+        end
+
+        def update
+          greentea = Greentea.find(params[:id])
+          if greentea.update(greentea_params)
+            render_greentea(greentea)
+          else
+            render_unprocessable(greentea)
+          end
+        end
+
+        def destroy
+          greentea = Greentea.find(params[:id])
+          greentea.destroy!
+          head :no_content
+        end
+
+        private
+
+        def greentea_params
+          permitted = params.require(:greentea).permit(
+            :name, :description, :address, :access, :phone_number,
+            :business_hours, :holiday, :homepage, :closed, :img,
+            :latitude, :longitude, genre_ids: []
+          )
+          permitted[:closed] = normalize_closed(permitted[:closed]) if permitted.key?(:closed)
+          permitted
+        end
+
+        # 作成・更新の戻りは読み取り系の詳細契約（GreenteaDetailSerializer）と同形にする。
+        def render_greentea(greentea, status: :ok)
+          render_resource(
+            greentea,
+            serializer: GreenteaDetailSerializer,
+            root: :greentea,
+            status: status,
+            serializer_params: {
+              likes_count: greentea.greentea_likes.size,
+              nearby_temples: nearby_temples_for(greentea),
+              liked_by_current_user: current_user.greentea_likes.exists?(greentea_id: greentea.id),
+              current_user_id: current_user.id
+            }
+          )
+        end
+
+        def nearby_temples_for(greentea)
+          return [] unless greentea.latitude && greentea.longitude
+
+          Temple
+            .within(1.5, origin: [greentea.latitude, greentea.longitude])
+            .by_distance(origin: [greentea.latitude, greentea.longitude])
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/templecomments_controller.rb
+++ b/app/controllers/api/v1/admin/templecomments_controller.rb
@@ -1,0 +1,14 @@
+module Api
+  module V1
+    module Admin
+      # admin は所有者チェックをバイパスして任意の口コミを削除できる。
+      class TemplecommentsController < BaseController
+        def destroy
+          comment = Templecomment.find(params[:id])
+          comment.destroy!
+          head :no_content
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/admin/temples_controller.rb
+++ b/app/controllers/api/v1/admin/temples_controller.rb
@@ -1,0 +1,65 @@
+module Api
+  module V1
+    module Admin
+      class TemplesController < BaseController
+        def create
+          temple = Temple.new(temple_params)
+          if temple.save
+            render_temple(temple, status: :created)
+          else
+            render_unprocessable(temple)
+          end
+        end
+
+        def update
+          temple = Temple.find(params[:id])
+          if temple.update(temple_params)
+            render_temple(temple)
+          else
+            render_unprocessable(temple)
+          end
+        end
+
+        def destroy
+          temple = Temple.find(params[:id])
+          temple.destroy!
+          head :no_content
+        end
+
+        private
+
+        def temple_params
+          params.require(:temple).permit(
+            :name, :description, :address, :access, :phone_number,
+            :business_hours, :holiday, :homepage, :img,
+            :latitude, :longitude, area_ids: []
+          )
+        end
+
+        # 作成・更新の戻りは読み取り系の詳細契約（TempleDetailSerializer）と同形にする。
+        def render_temple(temple, status: :ok)
+          render_resource(
+            temple,
+            serializer: TempleDetailSerializer,
+            root: :temple,
+            status: status,
+            serializer_params: {
+              likes_count: temple.temple_likes.size,
+              nearby_greenteas: nearby_greenteas_for(temple),
+              liked_by_current_user: current_user.temple_likes.exists?(temple_id: temple.id),
+              current_user_id: current_user.id
+            }
+          )
+        end
+
+        def nearby_greenteas_for(temple)
+          return [] unless temple.latitude && temple.longitude
+
+          Greentea
+            .within(1.5, origin: [temple.latitude, temple.longitude])
+            .by_distance(origin: [temple.latitude, temple.longitude])
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -26,6 +26,14 @@ module Api
         render json: { error: 'Unauthorized' }, status: :unauthorized
       end
 
+      # 管理用 API の認可境界。未認証は 401 / admin 以外は 403 で弾く。
+      def require_admin!
+        return render json: { error: 'Unauthorized' }, status: :unauthorized unless current_user
+        return if current_user.admin?
+
+        render json: { error: 'Forbidden' }, status: :forbidden
+      end
+
       private
 
       def authenticate_with_token
@@ -53,10 +61,15 @@ module Api
       end
 
       def paginate(scope)
-        per_page = params[:per_page].to_i
-        per_page = DEFAULT_PER_PAGE if per_page <= 0
-        per_page = MAX_PER_PAGE if per_page > MAX_PER_PAGE
         scope.page(params[:page]).per(per_page)
+      end
+
+      def per_page
+        value = params[:per_page].to_i
+        return DEFAULT_PER_PAGE if value <= 0
+        return MAX_PER_PAGE if value > MAX_PER_PAGE
+
+        value
       end
 
       def render_collection(records, serializer:, root: :data, serializer_params: {})
@@ -67,9 +80,9 @@ module Api
         }
       end
 
-      def render_resource(record, serializer:, root: :data, serializer_params: {})
+      def render_resource(record, serializer:, root: :data, serializer_params: {}, status: :ok)
         serialized = serializer.new(record, params: serializer_params).serializable_hash
-        render json: { root => flatten_serialized(serialized[:data]) }
+        render json: { root => flatten_serialized(serialized[:data]) }, status: status
       end
 
       # ジャンル / エリアのような件数の少ない参照リストはページネーションせず全件返す。

--- a/app/models/greentea.rb
+++ b/app/models/greentea.rb
@@ -9,6 +9,9 @@ class Greentea < ApplicationRecord
   has_many :greentea_likes, dependent: :destroy
   has_many :users, through: :greentea_likes
   has_many :greenteacomments, dependent: :destroy
+  # モデルルートに含まれる polymorphic な RouteSpot。店舗削除時に孤立行が残ると
+  # RouteDetailSerializer が spottable=nil を参照して 500 になるため一緒に削除する。
+  has_many :route_spots, as: :spottable, dependent: :destroy
 
   validates :name, presence: true
   validates :description, presence: true

--- a/app/models/temple.rb
+++ b/app/models/temple.rb
@@ -4,6 +4,9 @@ class Temple < ApplicationRecord
   has_many :temple_likes, dependent: :destroy
   has_many :users, through: :temple_likes
   has_many :templecomments, dependent: :destroy
+  # モデルルートに含まれる polymorphic な RouteSpot。神社削除時に孤立行が残ると
+  # RouteDetailSerializer が spottable=nil を参照して 500 になるため一緒に削除する。
+  has_many :route_spots, as: :spottable, dependent: :destroy
 
   validates :name, presence: true
   validates :description, presence: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,15 @@ Rails.application.routes.draw do
       resources :temple_likes, only: %i[index create destroy]
       resources :greenteacomments, only: %i[index create destroy]
       resources :templecomments, only: %i[index create destroy]
+
+      # 管理用 API（admin 権限必須）。抹茶店・神社の CRUD とコメントモデレーション。
+      namespace :admin do
+        resources :greenteas, only: %i[create update destroy]
+        resources :temples, only: %i[create update destroy]
+        resources :comments, only: %i[index]
+        resources :greenteacomments, only: %i[destroy]
+        resources :templecomments, only: %i[destroy]
+      end
     end
 
     match '*unmatched', to: 'v1/base#route_not_found', via: :all

--- a/spec/requests/api/v1/admin/comments_spec.rb
+++ b/spec/requests/api/v1/admin/comments_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Admin::Comments', type: :request do
+  let(:admin) { User.create!(name: '管理者', role: :admin) }
+  let(:general) { User.create!(name: '一般ユーザー', role: :general) }
+  let(:commenter) { User.create!(name: '投稿者') }
+  let(:admin_token) { JwtService.encode({ user_id: admin.id }) }
+  let(:admin_auth) { { 'Authorization' => "Bearer #{admin_token}" } }
+
+  let(:greentea) { create(:greentea) }
+  let(:temple) { create(:temple) }
+  let!(:greentea_comment) { create(:greenteacomment, user: commenter, greentea: greentea) }
+  let!(:temple_comment) { create(:templecomment, user: commenter, temple: temple) }
+
+  describe 'GET /api/v1/admin/comments' do
+    it 'returns 401 when unauthenticated' do
+      get '/api/v1/admin/comments'
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'returns 403 for a non-admin user' do
+      token = JwtService.encode({ user_id: general.id })
+      get '/api/v1/admin/comments', headers: { 'Authorization' => "Bearer #{token}" }
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'lists greentea and temple comments with meta' do
+      get '/api/v1/admin/comments', headers: admin_auth
+
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      types = json['comments'].map { |c| c['type'] }
+      expect(types).to contain_exactly('greentea', 'temple')
+      expect(json['meta']).to include('current_page' => 1, 'total_pages' => 1, 'total_count' => 2)
+    end
+
+    it 'filters by type' do
+      get '/api/v1/admin/comments', params: { type: 'greentea' }, headers: admin_auth
+
+      expect(response).to have_http_status(:ok)
+      comments = response.parsed_body['comments']
+      expect(comments.map { |c| c['type'] }).to all(eq('greentea'))
+      expect(comments.first).to include('greentea_id' => greentea.id)
+    end
+  end
+
+  describe 'DELETE /api/v1/admin/greenteacomments/:id' do
+    it "deletes another user's comment and returns 204" do
+      expect {
+        delete "/api/v1/admin/greenteacomments/#{greentea_comment.id}", headers: admin_auth
+      }.to change(Greenteacomment, :count).by(-1)
+
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it 'returns 403 for a non-admin user' do
+      token = JwtService.encode({ user_id: general.id })
+      delete "/api/v1/admin/greenteacomments/#{greentea_comment.id}",
+             headers: { 'Authorization' => "Bearer #{token}" }
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'DELETE /api/v1/admin/templecomments/:id' do
+    it "deletes another user's comment and returns 204" do
+      expect {
+        delete "/api/v1/admin/templecomments/#{temple_comment.id}", headers: admin_auth
+      }.to change(Templecomment, :count).by(-1)
+
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+end

--- a/spec/requests/api/v1/admin/comments_spec.rb
+++ b/spec/requests/api/v1/admin/comments_spec.rb
@@ -69,5 +69,12 @@ RSpec.describe 'Api::V1::Admin::Comments', type: :request do
 
       expect(response).to have_http_status(:no_content)
     end
+
+    it 'returns 403 for a non-admin user' do
+      token = JwtService.encode({ user_id: general.id })
+      delete "/api/v1/admin/templecomments/#{temple_comment.id}",
+             headers: { 'Authorization' => "Bearer #{token}" }
+      expect(response).to have_http_status(:forbidden)
+    end
   end
 end

--- a/spec/requests/api/v1/admin/greenteas_spec.rb
+++ b/spec/requests/api/v1/admin/greenteas_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Admin::Greenteas', type: :request do
+  let(:admin) { User.create!(name: '管理者', role: :admin) }
+  let(:general) { User.create!(name: '一般ユーザー', role: :general) }
+  let(:admin_token) { JwtService.encode({ user_id: admin.id }) }
+  let(:admin_auth) { { 'Authorization' => "Bearer #{admin_token}" } }
+  let(:genre) { create(:genre) }
+
+  let(:valid_attributes) do
+    {
+      name: '茶寮都路里 祇園本店',
+      description: '美味しい抹茶パフェの店',
+      address: '京都市東山区',
+      access: '祇園四条駅から徒歩5分',
+      phone_number: '075-561-2257',
+      business_hours: '10:00-21:00',
+      holiday: '不定休',
+      homepage: 'https://example.com/tsujiri',
+      closed: false,
+      img: 'https://example.com/images/tsujiri.jpg',
+      latitude: 35.0036,
+      longitude: 135.7752,
+      genre_ids: [genre.id]
+    }
+  end
+
+  describe 'POST /api/v1/admin/greenteas' do
+    context 'when unauthenticated' do
+      it 'returns 401' do
+        post '/api/v1/admin/greenteas', params: { greentea: valid_attributes }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated as a non-admin user' do
+      let(:token) { JwtService.encode({ user_id: general.id }) }
+
+      it 'returns 403' do
+        post '/api/v1/admin/greenteas',
+             params: { greentea: valid_attributes },
+             headers: { 'Authorization' => "Bearer #{token}" }
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'when authenticated as an admin' do
+      it 'creates a greentea and returns 201 with the detail contract' do
+        expect {
+          post '/api/v1/admin/greenteas', params: { greentea: valid_attributes }, headers: admin_auth
+        }.to change(Greentea, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        body = response.parsed_body['greentea']
+        expect(body).to include(
+          'name' => '茶寮都路里 祇園本店',
+          'closed' => false,
+          'likes_count' => 0,
+          'img' => 'https://example.com/images/tsujiri.jpg'
+        )
+        expect(body['genres']).to contain_exactly('id' => genre.id, 'name' => genre.name)
+        expect(body).to have_key('nearby_temples')
+      end
+
+      it 'returns 422 with errors when invalid' do
+        post '/api/v1/admin/greenteas',
+             params: { greentea: valid_attributes.merge(name: '', description: '') },
+             headers: admin_auth
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['errors']).to include('name', 'description')
+      end
+    end
+  end
+
+  describe 'PATCH /api/v1/admin/greenteas/:id' do
+    let(:greentea) { create(:greentea) }
+
+    it 'updates the greentea and returns 200' do
+      patch "/api/v1/admin/greenteas/#{greentea.id}",
+            params: { greentea: { name: '更新後の店名', closed: true } },
+            headers: admin_auth
+
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body['greentea']
+      expect(body).to include('name' => '更新後の店名', 'closed' => true)
+      expect(greentea.reload.name).to eq('更新後の店名')
+    end
+
+    it 'returns 403 for a non-admin user' do
+      token = JwtService.encode({ user_id: general.id })
+      patch "/api/v1/admin/greenteas/#{greentea.id}",
+            params: { greentea: { name: 'x' } },
+            headers: { 'Authorization' => "Bearer #{token}" }
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'DELETE /api/v1/admin/greenteas/:id' do
+    let!(:greentea) { create(:greentea) }
+
+    it 'deletes the greentea and returns 204' do
+      expect {
+        delete "/api/v1/admin/greenteas/#{greentea.id}", headers: admin_auth
+      }.to change(Greentea, :count).by(-1)
+
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it 'returns 401 when unauthenticated' do
+      delete "/api/v1/admin/greenteas/#{greentea.id}"
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end

--- a/spec/requests/api/v1/admin/greenteas_spec.rb
+++ b/spec/requests/api/v1/admin/greenteas_spec.rb
@@ -111,5 +111,16 @@ RSpec.describe 'Api::V1::Admin::Greenteas', type: :request do
       delete "/api/v1/admin/greenteas/#{greentea.id}"
       expect(response).to have_http_status(:unauthorized)
     end
+
+    it 'also removes route spots referencing the greentea (no orphan rows)' do
+      route = create(:route)
+      route_spot = create(:route_spot, route: route, spottable: greentea, position: 2)
+
+      expect {
+        delete "/api/v1/admin/greenteas/#{greentea.id}", headers: admin_auth
+      }.to change(RouteSpot, :count).by(-1)
+
+      expect(RouteSpot.exists?(route_spot.id)).to be(false)
+    end
   end
 end

--- a/spec/requests/api/v1/admin/temples_spec.rb
+++ b/spec/requests/api/v1/admin/temples_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Admin::Temples', type: :request do
+  let(:admin) { User.create!(name: '管理者', role: :admin) }
+  let(:general) { User.create!(name: '一般ユーザー', role: :general) }
+  let(:admin_token) { JwtService.encode({ user_id: admin.id }) }
+  let(:admin_auth) { { 'Authorization' => "Bearer #{admin_token}" } }
+  let(:area) { create(:area) }
+
+  let(:valid_attributes) do
+    {
+      name: '伏見稲荷大社',
+      description: '千本鳥居で有名な神社',
+      address: '京都市伏見区',
+      access: '稲荷駅すぐ',
+      phone_number: '075-641-7331',
+      business_hours: '24時間',
+      holiday: 'なし',
+      homepage: 'https://inari.jp',
+      img: 'https://example.com/images/inari.jpg',
+      latitude: 34.9671,
+      longitude: 135.7727,
+      area_ids: [area.id]
+    }
+  end
+
+  describe 'POST /api/v1/admin/temples' do
+    context 'when unauthenticated' do
+      it 'returns 401' do
+        post '/api/v1/admin/temples', params: { temple: valid_attributes }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated as a non-admin user' do
+      let(:token) { JwtService.encode({ user_id: general.id }) }
+
+      it 'returns 403' do
+        post '/api/v1/admin/temples',
+             params: { temple: valid_attributes },
+             headers: { 'Authorization' => "Bearer #{token}" }
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'when authenticated as an admin' do
+      it 'creates a temple and returns 201 with the detail contract' do
+        expect {
+          post '/api/v1/admin/temples', params: { temple: valid_attributes }, headers: admin_auth
+        }.to change(Temple, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        body = response.parsed_body['temple']
+        expect(body).to include('name' => '伏見稲荷大社', 'likes_count' => 0)
+        expect(body['areas']).to contain_exactly('id' => area.id, 'name' => area.name)
+        expect(body).to have_key('nearby_greenteas')
+      end
+
+      it 'returns 422 with errors when invalid' do
+        post '/api/v1/admin/temples',
+             params: { temple: valid_attributes.merge(name: '', description: '') },
+             headers: admin_auth
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['errors']).to include('name', 'description')
+      end
+    end
+  end
+
+  describe 'PATCH /api/v1/admin/temples/:id' do
+    let(:temple) { create(:temple) }
+
+    it 'updates the temple and returns 200' do
+      patch "/api/v1/admin/temples/#{temple.id}",
+            params: { temple: { name: '更新後の神社名' } },
+            headers: admin_auth
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['temple']).to include('name' => '更新後の神社名')
+      expect(temple.reload.name).to eq('更新後の神社名')
+    end
+  end
+
+  describe 'DELETE /api/v1/admin/temples/:id' do
+    let!(:temple) { create(:temple) }
+
+    it 'deletes the temple and returns 204' do
+      expect {
+        delete "/api/v1/admin/temples/#{temple.id}", headers: admin_auth
+      }.to change(Temple, :count).by(-1)
+
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+end

--- a/spec/requests/api/v1/admin/temples_spec.rb
+++ b/spec/requests/api/v1/admin/temples_spec.rb
@@ -64,6 +64,15 @@ RSpec.describe 'Api::V1::Admin::Temples', type: :request do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.parsed_body['errors']).to include('name', 'description')
       end
+
+      it 'returns 422 (not 500) when latitude/longitude are missing' do
+        post '/api/v1/admin/temples',
+             params: { temple: valid_attributes.merge(latitude: nil, longitude: nil) },
+             headers: admin_auth
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['errors']).to be_present
+      end
     end
   end
 


### PR DESCRIPTION
## 概要

matcha-to-jinja#71（フロント管理画面）が依存する **管理用の書き込み API** を実装しました。
抹茶店・神社の CRUD と、口コミのモデレーション（横断一覧・削除）を提供します。
全エンドポイントで Bearer JWT 認証必須かつ `current_user.role == "admin"` のみ許可します。

- 名前空間: `/api/v1/admin/*`（管理用を明示的に分離）
- 認可: 未認証 → `401` / admin でない → `403`
- レスポンス: 作成・更新は既存の読み取り系 **詳細 serializer（`*DetailSerializer`）と同形**で返却
- 画像（MVP）: `img` は URL 文字列をそのまま保存（ファイルアップロード受け口は後続）
- `users.role`（`enum role: { general: 0, admin: 1 }`）は既存のため migration なし

Closes #187

### エンドポイント

```
POST   /api/v1/admin/greenteas            # 作成 (201)
PATCH  /api/v1/admin/greenteas/:id        # 更新 (200)
DELETE /api/v1/admin/greenteas/:id        # 削除 (204)
POST   /api/v1/admin/temples              # 作成 (201)
PATCH  /api/v1/admin/temples/:id          # 更新 (200)
DELETE /api/v1/admin/temples/:id          # 削除 (204)
GET    /api/v1/admin/comments             # 口コミ横断一覧（type / spot_id で絞り込み）
DELETE /api/v1/admin/greenteacomments/:id # 口コミ削除（admin は他人のも可）
DELETE /api/v1/admin/templecomments/:id   # 口コミ削除（admin は他人のも可）
```

### 主な実装

- `Api::V1::BaseController#require_admin!` を追加（未認証 401 / 非 admin 403）
- `Api::V1::Admin::BaseController` を新設し `before_action :require_admin!` で認可を一元化
- 抹茶店・神社コントローラ
  - Strong Parameters で各フィールド + `genre_ids` / `area_ids` の関連付けに対応
  - `closed` はフロントの boolean を DB の integer（0/1）に正規化
  - バリデーション失敗は `422` + `{ "errors": {...} }`
- コメントモデレーション
  - `CommentsController#index` で抹茶店・神社の口コミを横断集約（`type` / `spot_id` で絞り込み、`meta` 付き）
  - 削除系は admin のため所有者チェックをバイパス
- `BaseController`: `per_page` をメソッド抽出 / `render_resource` に `status:` を追加（後方互換）

## 確認方法

1. `git fetch && git switch claude/issue-to-pr-k69z83`
2. admin ユーザー（`role: :admin`）の JWT を発行
3. `POST /api/v1/admin/greenteas` で抹茶店を作成 → `201` + `{ "greentea": { ...詳細契約 } }` を確認
4. 非 admin / 未認証で同エンドポイントを叩き `403` / `401` で弾かれることを確認
5. `GET /api/v1/admin/comments` で口コミ横断一覧、`DELETE /api/v1/admin/greenteacomments/:id` で他人の口コミも削除できることを確認

## 影響範囲

- 新規: `app/controllers/api/v1/admin/` 配下と `spec/requests/api/v1/admin/`
- 既存変更: `app/controllers/api/v1/base_controller.rb`（後方互換な追加のみ）、`config/routes.rb`（api/v1 配下に admin 名前空間を追加）
- 既存 Web 画面・読み取り系 API への破壊的変更はなし

## チェックリスト

- [x] Lint のチェックをパスした（追加コードに RuboCop 違反なし）
- [x] リクエストスペックを追加した（201/200/204、401/403/422 を網羅、admin 配下 21 examples / 0 failures）
- [x] 既存 request / model / service spec をパスした（302 examples / 0 failures）
- [ ] system spec はローカル環境で Chrome 取得不可のため未実行（本変更はビュー/JS 非対象）

## コメント

- `users.role` は PR #186 で確定済みのため本 PR では migration を追加していません。
- 画像は MVP 方針どおり URL 文字列をそのまま保存しています（CarrierWave のファイルアップロード受け口は後続 issue）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01815kDRGbNrp9feGKAxGpTy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin API endpoints for managing greenteas and temples, including create, update, delete, and list actions.
  * Added comment moderation endpoints to view mixed comment types and remove individual comments.
* **Bug Fixes**
  * Improved API responses for validation failures with clearer error output.
  * Tightened access control so admin endpoints now properly return unauthorized or forbidden responses.
  * Standardized handling of “closed” values and pagination limits for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->