### PR TITLE
docs: Vercel の Dockerfile 対応検討を追記（Cloud Run 継続の判断記録）

### DIFF
--- a/docs/infra/deploy-cost-comparison.md
+++ b/docs/infra/deploy-cost-comparison.md
@@ -177,3 +177,51 @@
 
 - matcha-to-jinja: `docs/migration-plan.md`（「環境構成」「GCP Cloud Run デプロイ手順」「Neon PostgreSQL セットアップ」）
 - 関連 issue: #113 〜 #118（API 化 → デプロイ）
+
+---
+
+## 付録: Vercel の Dockerfile 対応の検討（as-of 2026-07-01）
+
+> 背景: Vercel が「任意の Dockerfile を動かせる」機能を発表したのを受け、**Rails 本体も含めて全部 Vercel に寄せられないか / GCP より安くならないか** を検討した記録。
+> 出典: [Run any Dockerfile on Vercel](https://vercel.com/blog/dockerfile-on-vercel) / [Fluid compute pricing](https://vercel.com/docs/functions/usage-and-pricing) / [Active CPU pricing](https://vercel.com/blog/introducing-active-cpu-pricing-for-fluid-compute)
+
+### 何ができるようになったか
+
+- リポジトリに `Dockerfile.vercel` を置くと、Vercel がイメージをビルド・保存・デプロイし、**Fluid compute 上でオートスケール**する。
+- **Rails は公式にサポート対象**（Rails / Laravel / Spring Boot / Express / FastAPI / nginx など）。唯一のルールは **サーバが `$PORT`（デフォルト 80）で listen** すること。
+- 既存 `Dockerfile` は `CMD ... -p ${PORT}` で **既に `$PORT` listen 対応済み**なので、技術的には流用可能。
+
+### 課金モデルの違い（Cloud Run と比較）
+
+| | GCP Cloud Run | Vercel Fluid compute |
+|---|---|---|
+| 基本料金 | **なし**（従量のみ） | プラン必須。**Hobby=無料（非商用・上限あり）** / Pro=$20/人・月 |
+| CPU 課金 | vCPU 秒。**リクエスト処理中はずっと**（DB 待ちも含む） | **Active CPU $0.128/時**。**コード実行中だけ**（I/O 待ちは課金停止） |
+| メモリ課金 | GiB 秒 | Provisioned Memory $0.0106/GB時（処理中のみ） |
+| リクエスト | 100万 $0.40（月200万まで無料） | Invocations 100万 $0.60 |
+| 無料枠 | **月 18万 vCPU秒 / 36万 GiB秒 / 200万 req** | Hobby プラン枠内 |
+| アイドル | 0円（scale to zero） | リクエスト間は 0 |
+
+- **低トラフィックの本プロジェクトでは、使用量自体はどちらも誤差レベルに安い。** 勝敗は「無料枠と基本料金」で決まる。
+- Vercel は **I/O 待ちを課金しない**のが強みで、DB(Neon)・Google API 待ちが多い Rails と相性は悪くない。ただし **商用運用は Hobby 不可 → Pro $20/月の下駄**が要る。
+
+### 結論: 現状維持（変更なし）
+
+- 方針は **「Vercel は無料(Hobby)で使う」**。Hobby は非商用・個人利用向けで、常時稼働のバックエンドを載せる用途には枠・規約的に不向き。
+- よって **Rails は引き続き GCP Cloud Run**（無料枠＋基本料金なしで低トラフィックなら実質 0 円、かつデプロイ定義が既に揃っている）。**現行構成（Vercel=フロント / Cloud Run=Rails / Neon=DB）から変更しない。**
+- **将来 Vercel が Pro 前提になった場合のみ**（フロントで $20/月を払うなら追加固定費なしで載る）、「全部 Vercel に集約して運用を一本化」を再検討する余地あり。
+
+### 「全部 Vercel」にする場合に必要だった対応（＝今回は見送り）
+
+再検討時のためにメモとして残す:
+
+1. `Dockerfile.vercel` を追加（既存 `Dockerfile` ベース。default PORT を 80 に合わせる）。
+2. **画像アップロードを外部ストレージへ**（コンテナはステートレス＝ローカル保存は消える）。元々 GCS 化が前提（runbook「7. 将来対応」）なので方針は同じ。
+3. **Host Authorization に Vercel ドメインを追加**（`config/environments/production.rb` は現状 `*.run.app` のみ自動許可）。`*.vercel.app` / カスタムドメインは `APP_HOSTS` で許可する必要あり。
+4. 同一ドメイン配下にまとめられれば CORS を不要化できる（別ドメインなら現行の `FRONTEND_URL` ベースの CORS のまま）。
+
+### リポジトリ分割について
+
+- フロント(`matcha-to-jinja`) と バックエンド(`greentea_temple`) が **別リポジトリなのは標準的な構成で、デプロイ先が Vercel / GCP どちらでも問題ない**。
+- Vercel でも **1 リポジトリ = 1 プロジェクト**として独立にデプロイでき、モノレポ化は不要。
+- つなぎ込み（フロントに API URL を env で渡す / バックエンドは CORS・`APP_HOSTS` でフロントを許可）は **既に実装済み**（`config/initializers/cors.rb`・`production.rb`）。分割のままで完結する。

--- a/docs/infra/deploy-cost-comparison.md
+++ b/docs/infra/deploy-cost-comparison.md
@@ -175,7 +175,7 @@
 
 ### その他
 
-- matcha-to-jinja: `docs/migration-plan.md`（「環境構成」「GCP Cloud Run デプロイ手順」「Neon PostgreSQL セットアップ」）
+- matcha-to-jinja（別リポジトリ）の [`docs/migration-plan.md`](https://github.com/hiiragi17/matcha-to-jinja/blob/main/docs/migration-plan.md)（「環境構成」「GCP Cloud Run デプロイ手順」「Neon PostgreSQL セットアップ」）。**本リポジトリには存在しない**（参照先はフロントエンドのリポジトリ）
 - 関連 issue: #113 〜 #118（API 化 → デプロイ）
 
 ---
@@ -189,7 +189,7 @@
 
 - リポジトリに `Dockerfile.vercel` を置くと、Vercel がイメージをビルド・保存・デプロイし、**Fluid compute 上でオートスケール**する。
 - **Rails は公式にサポート対象**（Rails / Laravel / Spring Boot / Express / FastAPI / nginx など）。唯一のルールは **サーバが `$PORT`（デフォルト 80）で listen** すること。
-- 既存 `Dockerfile` は `CMD ... -p ${PORT}` で **既に `$PORT` listen 対応済み**なので、技術的には流用可能。
+- 既存 `Dockerfile` は `CMD ... -p ${PORT}` で `$PORT` を listen する作りなので流用の下地はある。ただし **イメージに `ENV PORT=8080` が焼き込まれている**点に注意。Vercel はデフォルトで **ポート 80** にルーティングするため、Vercel 版では **Vercel 側の `PORT` を 8080 に設定する**か、**イメージの `ENV PORT` 既定値を外して Vercel の 80 を通す**必要がある（そのまま流用するとビルドは通ってもトラフィックが届かない）。
 
 ### 課金モデルの違い（Cloud Run と比較）
 
@@ -197,13 +197,15 @@
 |---|---|---|
 | 基本料金 | **なし**（従量のみ） | プラン必須。**Hobby=無料（非商用・上限あり）** / Pro=$20/人・月 |
 | CPU 課金 | vCPU 秒。**リクエスト処理中はずっと**（DB 待ちも含む） | **Active CPU $0.128/時**。**コード実行中だけ**（I/O 待ちは課金停止） |
-| メモリ課金 | GiB 秒 | Provisioned Memory $0.0106/GB時（処理中のみ） |
+| メモリ課金 | GiB 秒 | Provisioned Memory $0.0106/GB時。**リクエスト処理中は I/O 待ちも含めて課金**（最後の in-flight リクエストが終わるまで） |
 | リクエスト | 100万 $0.40（月200万まで無料） | Invocations 100万 $0.60 |
 | 無料枠 | **月 18万 vCPU秒 / 36万 GiB秒 / 200万 req** | Hobby プラン枠内 |
 | アイドル | 0円（scale to zero） | リクエスト間は 0 |
 
+> ⚠️ **単位に注意**: Cloud Run は「**秒**」課金、Vercel は「**時**」課金で表記が異なる。ざっくり横並び比較するなら Vercel の「/時」を **3600 で割る**と「/秒」換算になる（例: Active CPU $0.128/時 ≒ $0.0000356/秒）。
+
 - **低トラフィックの本プロジェクトでは、使用量自体はどちらも誤差レベルに安い。** 勝敗は「無料枠と基本料金」で決まる。
-- Vercel は **I/O 待ちを課金しない**のが強みで、DB(Neon)・Google API 待ちが多い Rails と相性は悪くない。ただし **商用運用は Hobby 不可 → Pro $20/月の下駄**が要る。
+- Vercel は **CPU について I/O 待ちを課金しない**のが強みで、DB(Neon)・Google API 待ちが多い Rails と相性は悪くない。**ただしメモリ（Provisioned Memory）はリクエスト処理が続く限り I/O 待ちも含めて課金される**ため、「I/O 待ちは一切タダ」ではない点に注意。さらに **商用運用は Hobby 不可 → Pro $20/月の下駄**が要る。
 
 ### 結論: 現状維持（変更なし）
 


### PR DESCRIPTION
## 概要

Vercel が「任意の Dockerfile を Fluid compute 上で動かす」機能を発表したのを受けて、**Rails 本体も含めて全部 Vercel に寄せられないか / GCP より安くならないか** を検討しました。その結論と根拠を、既存の [`docs/infra/deploy-cost-comparison.md`](../blob/main/docs/infra/deploy-cost-comparison.md) 末尾に **日付つきの付録**として追記するドキュメントのみの変更です。

検討の結論は **現状維持（Vercel=フロント / Cloud Run=Rails / Neon=DB から変更しない）**。

- Vercel の新機能は Rails を公式サポートし、既存 `Dockerfile` も `$PORT` listen 済みで技術的には流用可能。
- ただし本プロジェクトの方針は **「Vercel は無料(Hobby)で使う」**。Hobby は非商用・個人利用向けで常時稼働バックエンドには不向き。
- 低トラフィックでは使用量はどちらも誤差レベルに安く、**無料枠＋基本料金なしの Cloud Run が実質 0 円**で有利。
- 将来 Vercel が Pro 前提になった場合のみ「全部 Vercel 集約」を再検討する余地あり、というメモも残しました。
- あわせて **リポジトリ分割（フロント別リポ）は Vercel/GCP どちらでも問題ない**旨も明記。

出典（本文中にもリンクあり）:
- https://vercel.com/blog/dockerfile-on-vercel
- https://vercel.com/docs/functions/usage-and-pricing
- https://vercel.com/blog/introducing-active-cpu-pricing-for-fluid-compute

## 確認方法

コード変更はなく、ドキュメント追記のみです。

1. [`docs/infra/deploy-cost-comparison.md`](../blob/claude/verve-docker-support-s0cvsl/docs/infra/deploy-cost-comparison.md) 末尾の **「付録: Vercel の Dockerfile 対応の検討（as-of 2026-07-01）」** を確認してください。
2. 既存セクション（特に本文中の「5. 参考」への参照）が壊れていないこと（番号を振り直さず付録として追記しています）。

## 影響範囲

- `docs/infra/deploy-cost-comparison.md` のみ。**アプリのコード・設定・デプロイ定義への影響はなし**。
- 既存の `Dockerfile` / `config/initializers/cors.rb` / `config/environments/production.rb` は変更していません（付録内で現状を参照しているだけ）。

## チェックリスト

- [x] ドキュメントのみの変更（コード変更なし）
- [x] 既存セクションの番号参照を壊していない（付録として末尾に追記）
- [x] 出典 URL を本文に明記（as-of 日付つき）
- [ ] Lint / テスト: ドキュメントのみのため対象外

## コメント

- 料金の数値は as-of 2026-07-01 の各社公式ページ参照です。既存資料の方針どおり「採用前に最新の公式ページを確認」の注意はこの付録にも当てはまります。
- 「全部 Vercel」に寄せる場合に必要な対応（`Dockerfile.vercel` 追加 / 画像の外部ストレージ化 / `APP_HOSTS` に Vercel ドメイン追加）は、再検討時に着手できるよう付録内にメモとして残しています。

---
_Generated by [Claude Code](https://claude.ai/code/session_017q4X5stosVKHoLhBsuzVND)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an appendix covering Vercel’s Dockerfile support and deployment behavior.
  * Included a cost comparison between Cloud Run and Vercel Fluid Compute, with notes on free tiers and low-traffic usage.
  * Clarified the current deployment stance: keep Rails on Cloud Run and use Vercel only within the free plan.
  * Listed requirements for a future full-Vercel setup, including app routing, image handling, and domain-related settings.
  * Reaffirmed the split-repository approach and independent deployment model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->