### PR TITLE
test: OauthsController（Web セッション OAuth コールバック）の request spec を追加

### DIFF
--- a/spec/requests/oauths_spec.rb
+++ b/spec/requests/oauths_spec.rb
@@ -25,6 +25,9 @@ RSpec.describe 'OAuths (Web セッション OAuth)', type: :request do
         get '/oauth/callback', params: { provider: 'google', denied: '1' }
 
         expect(response).to redirect_to(login_path)
+        # :warning は add_flash_types 未登録のため伝播しない。将来 :warning が
+        # 登録され挙動が変わった場合に気づけるよう、現状を明示的に固定する。
+        expect(flash[:warning]).to be_nil
       end
 
       it 'error=ACCESS_DENIED でもログイン画面へ戻す' do
@@ -33,6 +36,7 @@ RSpec.describe 'OAuths (Web セッション OAuth)', type: :request do
         get '/oauth/callback', params: { provider: 'line', error: 'ACCESS_DENIED' }
 
         expect(response).to redirect_to(login_path)
+        expect(flash[:warning]).to be_nil
       end
 
       it 'キャンセル時はユーザーを作らない' do

--- a/spec/requests/oauths_spec.rb
+++ b/spec/requests/oauths_spec.rb
@@ -1,0 +1,122 @@
+require 'rails_helper'
+
+# Web 側（Sorcery セッション）の OAuth コールバックの分岐を検証する。
+# 外部プロバイダとの通信を担う Sorcery のメソッド（login_from / create_from /
+# login_at）だけをスタブし、コントローラ自身の分岐・redirect・flash を確認する。
+RSpec.describe 'OAuths (Web セッション OAuth)', type: :request do
+  # login_from / create_from は Sorcery が provider 名（文字列）を引数に取る。
+  def stub_login_from(return_value)
+    allow_any_instance_of(OauthsController).to receive(:login_from).and_return(return_value)
+  end
+
+  def stub_create_from(return_value)
+    allow_any_instance_of(OauthsController).to receive(:create_from).and_return(return_value)
+  end
+
+  describe 'GET /oauth/callback' do
+    # NOTE: コントローラは `warning:` flash を渡すが、ApplicationController の
+    # add_flash_types は :success / :error / :info のみ登録しており :warning は
+    # 未登録のため、この flash は実際には伝播しない（現状の実挙動）。
+    # ここではログイン画面へ戻す（＝新規作成もログインもしない）ことを検証する。
+    context 'ユーザーがプロバイダ側でキャンセルした場合' do
+      it 'denied が付いていればログイン画面へ戻す' do
+        expect_any_instance_of(OauthsController).not_to receive(:login_from)
+
+        get '/oauth/callback', params: { provider: 'google', denied: '1' }
+
+        expect(response).to redirect_to(login_path)
+      end
+
+      it 'error=ACCESS_DENIED でもログイン画面へ戻す' do
+        expect_any_instance_of(OauthsController).not_to receive(:login_from)
+
+        get '/oauth/callback', params: { provider: 'line', error: 'ACCESS_DENIED' }
+
+        expect(response).to redirect_to(login_path)
+      end
+
+      it 'キャンセル時はユーザーを作らない' do
+        expect do
+          get '/oauth/callback', params: { provider: 'google', denied: '1' }
+        end.not_to change(User, :count)
+      end
+    end
+
+    context '既存ユーザーが login_from で解決できる場合' do
+      let(:user) { create(:user) }
+
+      before { stub_login_from(user) }
+
+      it 'ユーザーページへ遷移し成功メッセージを出す' do
+        get '/oauth/callback', params: { provider: 'google' }
+
+        expect(response).to redirect_to(user_path(user))
+        expect(flash[:success]).to eq('Googleアカウントでログインしました')
+      end
+
+      it 'create_from は呼ばれない（新規ユーザーを作らない）' do
+        expect_any_instance_of(OauthsController).not_to receive(:create_from)
+
+        expect do
+          get '/oauth/callback', params: { provider: 'google' }
+        end.not_to change(User, :count)
+      end
+    end
+
+    context 'login_from が nil で新規ユーザーを作成する場合' do
+      let(:new_user) { create(:user) }
+
+      before do
+        stub_login_from(nil)
+        stub_create_from(new_user)
+      end
+
+      it 'create_from の結果でログインしユーザーページへ遷移する' do
+        get '/oauth/callback', params: { provider: 'line' }
+
+        expect(response).to redirect_to(user_path(new_user))
+        expect(flash[:success]).to eq('Lineアカウントでログインしました')
+      end
+
+      it 'セッションフィクセーション対策として reset_session と auto_login を行う' do
+        expect_any_instance_of(OauthsController).to receive(:reset_session)
+        expect_any_instance_of(OauthsController).to receive(:auto_login).with(new_user)
+
+        get '/oauth/callback', params: { provider: 'line' }
+      end
+    end
+
+    context 'ログイン処理中に例外が発生した場合' do
+      before do
+        allow_any_instance_of(OauthsController)
+          .to receive(:login_from).and_raise(StandardError, 'boom')
+      end
+
+      it 'ログイン画面へ戻しエラーメッセージを出す' do
+        get '/oauth/callback', params: { provider: 'google' }
+
+        expect(response).to redirect_to(login_path)
+        expect(flash[:error]).to eq('Googleアカウントでのログインに失敗しました')
+      end
+    end
+  end
+
+  describe 'POST /oauth/callback' do
+    it 'GET と同じく callback を処理する' do
+      user = create(:user)
+      stub_login_from(user)
+
+      post '/oauth/callback', params: { provider: 'google' }
+
+      expect(response).to redirect_to(user_path(user))
+    end
+  end
+
+  describe 'GET /oauth/:provider' do
+    it 'login_at でプロバイダの認可画面へ委譲する' do
+      expect_any_instance_of(OauthsController).to receive(:login_at).with('google')
+
+      get '/oauth/google'
+    end
+  end
+end

--- a/spec/requests/oauths_spec.rb
+++ b/spec/requests/oauths_spec.rb
@@ -114,9 +114,17 @@ RSpec.describe 'OAuths (Web セッション OAuth)', type: :request do
 
   describe 'GET /oauth/:provider' do
     it 'login_at でプロバイダの認可画面へ委譲する' do
-      expect_any_instance_of(OauthsController).to receive(:login_at).with('google')
+      # login_at は本来プロバイダの認可 URL へリダイレクトする。素の receive で
+      # 潰すと nil を返し、oauths/oauth テンプレート不在で 500 になりうるため、
+      # スタブ側でリダイレクトを再現し、リクエストがエラーで通らないことも担保する。
+      expect_any_instance_of(OauthsController).to receive(:login_at) do |controller, provider|
+        expect(provider).to eq('google')
+        controller.redirect_to(login_path)
+      end
 
       get '/oauth/google'
+
+      expect(response).to redirect_to(login_path)
     end
   end
 end


### PR DESCRIPTION
## 概要

テストカバレッジを見直したところ、API 側（request spec / モデル / サービス / serializer）はエッジケースまで手厚くカバーされている一方で、**Web 側の Sorcery OAuth コールバック `OauthsController` にはテストが 1 つも無い**ことがわかりました。

`config/routes.rb` で現役のルート（`oauth/callback`・`oauth/:provider`）でありながら、以下のような無視できない分岐がノーカバーだったため、request spec を追加します。

- キャンセル（`denied` / `error=ACCESS_DENIED`）→ ログイン画面へ戻す
- 既存ユーザーが `login_from` で解決できる場合 → ユーザーページへ遷移
- `login_from` が `nil` の場合 → `create_from` で新規作成し、`reset_session` + `auto_login`（セッションフィクセーション対策）
- ログイン処理中の例外 → 握りつぶしてログイン画面へ戻す
- POST/GET どちらの `callback` も処理する / `oauth` アクションは `login_at` に委譲する

外部プロバイダ通信を担う Sorcery のメソッド（`login_from` / `create_from` / `login_at`）のみをスタブし、コントローラ自身の分岐・redirect を検証しています。

### 補足: テスト作成中に見つけた潜在的な挙動

キャンセル分岐は `redirect_to login_path, warning: '...'` としていますが、`ApplicationController` の `add_flash_types` に登録されているのは `:success / :error / :info` のみで **`:warning` は未登録**です。そのためキャンセルメッセージ（「ログインをキャンセルしました」）は実際には flash に載らず表示されません。

`ApplicationController` は「当面触らない」方針（CLAUDE.md）のため本 PR では**修正せず**、テストは現状の実挙動（ログイン画面へ戻る・メッセージは出ない）を検証する形とし、経緯を spec 内コメントに残しています。修正が必要かはご判断ください。

## 確認方法

1. `bundle exec rspec spec/requests/oauths_spec.rb` を実行し、10 examples が全て pass することを確認してください（ローカルで確認済み: `10 examples, 0 failures`）

## 影響範囲

- テストの追加のみ。アプリケーションコード（`app/`）への変更はありません。

## チェックリスト

- [x] ユニット / request テストを追加した
- [x] ユニットテストをパスした（`spec/requests/oauths_spec.rb`: 10 examples, 0 failures）

## コメント

「補足」に記載した `:warning` flash 未登録の件について、対応方針（登録するか / 別の flash type に寄せるか / 現状維持か）があればご指示ください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvdPB7f7MSaHWgT6FDeQ9L)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for OAuth sign-in and callback flows, including cancelled authorizations, existing-account sign-in, new-account creation, error handling, and provider redirects.
  * Verified the app returns users to the correct page and shows the appropriate success or error messages during OAuth login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->