### PR TITLE
docs: .env.example を追加し環境変数ドキュメントを実コードに合わせて修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,71 @@
+# =============================================================================
+# 抹茶と神社。(greentea_temple) 環境変数サンプル
+#
+# 使い方:
+#   cp .env.example .env
+#   → 各値を埋める（dotenv-rails 導入済みのため .env は自動で読み込まれる）
+#
+# ⚠️ .env は絶対にコミットしないこと（.gitignore 済み）。
+#    変数名はアプリの実コードが ENV[..] で参照している名前に合わせている。
+#    本番（Cloud Run）の設定は .github/workflows/deploy-cloud-run.yml と
+#    docs/infra/deploy-runbook.md を参照。
+# =============================================================================
+
+# --- Google Maps 系 --------------------------------------------------------
+# 取得: Google Cloud Console → 「APIとサービス」→ 対象 API を有効化 → 認証情報で API キー発行
+# https://console.cloud.google.com/apis/credentials
+
+# Geocoding API（住所 → 緯度経度）。config/initializers/geocoder.rb が参照。
+# seed 実行時に必須（未設定だと緯度経度が入らず距離検索が壊れる）。
+# サーバー側キーなので「API 制限: Geocoding API のみ」を推奨。
+GMAP_API=
+
+# Maps JavaScript API（地図描画）。app/views/**/*.erb から HTML に埋め込まれる。
+# ブラウザに露出するため「HTTP リファラー制限 + Maps JavaScript API のみ」を推奨。
+GOOGLE_MAP_API=
+
+# Directions API（モデルルートの経路・所要時間計算。#153）。
+# 未設定の場合 app/services/directions_service.rb は GOOGLE_MAPS_API_KEY に
+# フォールバックする（GOOGLE_MAP_API とは別名なので注意）。
+GOOGLE_DIRECTIONS_API_KEY=
+
+# --- OAuth -------------------------------------------------------------------
+# Google OAuth（ログイン）。config/initializers/sorcery.rb が参照。
+# 未設定の場合は credentials.yml.enc の google.client_id / google.client_secret に
+# フォールバックする。
+# 取得: Google Cloud Console → OAuth 同意画面を設定 → 認証情報 → OAuth クライアント ID
+#   リダイレクト URI 例（開発）: http://localhost:3001/oauth/callback?provider=google
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# LINE OAuth は環境変数では設定できない（sorcery.rb が encrypted credentials のみ参照）。
+#   bin/rails credentials:edit で以下を設定する:
+#     line:
+#       channel_id: "xxxx"
+#       channel_secret: "xxxx"
+# 取得: LINE Developers Console → プロバイダー作成 → LINE ログインチャネル作成
+# https://developers.line.biz/console/
+
+# --- API（Next.js フロント向け） ---------------------------------------------
+# JWT 署名鍵（HS256・#115）。app/services/jwt_service.rb が参照。
+# credentials の jwt_secret が優先され、未設定ならこの環境変数が使われる。
+# 生成例: bin/rails secret
+JWT_SECRET_KEY=
+
+# CORS の許可オリジン（config/initializers/cors.rb）。
+# 開発のデフォルトは http://localhost:3000 のため、ローカルでは未設定でもよい。
+# 本番: https://matcha-to-jinja.com
+# FRONTEND_URL=http://localhost:3000
+
+# --- 本番のみ（ローカル開発では不要） ----------------------------------------
+# Neon PostgreSQL の pooled 接続文字列（sslmode=require）。
+# ローカルは config/database.yml のローカル PostgreSQL 設定が使われる。
+# DATABASE_URL=
+
+# credentials.yml.enc の復号キー（config/master.key の中身）。
+# ローカルに config/master.key があれば設定不要。
+# RAILS_MASTER_KEY=
+
+# Host Authorization の追加許可ホスト（カンマ区切り・任意）。
+# 本番は *.run.app が自動許可され、カスタムドメインは本変数で追加する。
+# APP_HOSTS=matcha-to-jinja.com,www.matcha-to-jinja.com

--- a/.env.example
+++ b/.env.example
@@ -34,7 +34,10 @@ GOOGLE_DIRECTIONS_API_KEY=
 # 未設定の場合は credentials.yml.enc の google.client_id / google.client_secret に
 # フォールバックする。
 # 取得: Google Cloud Console → OAuth 同意画面を設定 → 認証情報 → OAuth クライアント ID
-#   リダイレクト URI 例（開発）: http://localhost:3001/oauth/callback?provider=google
+#   承認済みリダイレクト URI には、アプリが実際に送る callback URL
+#   （config/settings/development.yml の sorcery.google_callback_url）を登録する:
+#     開発: http://127.0.0.1:3000/oauth/callback?provider=google
+#   別ポート等で動かす場合は Google Cloud Console と development.yml の両方を合わせること。
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 

--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -92,8 +92,7 @@ jobs:
       # 環境変数名はアプリ実コードが ENV[..] で参照している名前に合わせている:
       #   - GMAP_API           : config/initializers/geocoder.rb
       #   - GOOGLE_MAP_API     : app/views/**/*.erb (Google Maps JS API key)
-      # CLAUDE.md 表記の `GOOGLE_GEOCODING_API_KEY` / `GOOGLE_MAPS_API_KEY`
-      # への統一は別タスクで実施する。
+      # （CLAUDE.md / .env.example も同名で統一済み）
       #
       # SECRET_KEY_BASE は credentials.yml.enc に持たせる場合 RAILS_MASTER_KEY
       # 経由で復号されるため不要。`secrets.SECRET_KEY_BASE` を unconditionally

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,16 +40,19 @@ bundle exec rubocop
 
 ## 必須環境変数
 
+サンプルは `.env.example` を参照（`cp .env.example .env` で開発用に利用。dotenv-rails 導入済み）。
+変数名は**実コードが `ENV[..]` で参照している名前**に合わせる。
+
 | 変数名 | 用途 |
 |---|---|
-| `GOOGLE_GEOCODING_API_KEY` | 住所 → 緯度経度（Geocoder） |
-| `GOOGLE_MAPS_API_KEY` | 地図描画（JS から参照）。`GOOGLE_DIRECTIONS_API_KEY` 未設定時は経路計算でも再利用 |
-| `GOOGLE_DIRECTIONS_API_KEY` | モデルルートの経路・所要時間計算（Directions API・#153）。未設定なら `GOOGLE_MAPS_API_KEY` にフォールバック |
-| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Google OAuth（#90 で Twitter から移行） |
-| `LINE_KEY` / `LINE_SECRET` | LINE OAuth |
-| `DATABASE_URL` | 本番 PostgreSQL（#118 で Neon へ移行予定） |
-| `FRONTEND_URL` | CORS allowlist。開発: `http://localhost:3000` / 本番: `https://matcha-to-jinja.com`（#113〜） |
-| `JWT_SECRET_KEY` | API 用 JWT 署名（#115〜） |
+| `GMAP_API` | 住所 → 緯度経度（Geocoder。`config/initializers/geocoder.rb`）。seed 実行時に必須 |
+| `GOOGLE_MAP_API` | 地図描画（Maps JavaScript API。`app/views/**/*.erb` から HTML に埋め込み） |
+| `GOOGLE_DIRECTIONS_API_KEY` | モデルルートの経路・所要時間計算（Directions API・#153）。未設定なら `GOOGLE_MAPS_API_KEY` にフォールバック（`app/services/directions_service.rb`。地図描画用の `GOOGLE_MAP_API` とは**別名**なので注意） |
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Google OAuth（#90 で Twitter から移行）。未設定時は credentials の `google.client_id` / `google.client_secret` にフォールバック |
+| （LINE は ENV 不可） | LINE OAuth は `credentials.yml.enc` の `line.channel_id` / `line.channel_secret` のみ参照（`config/initializers/sorcery.rb`）。環境変数では有効化されない |
+| `DATABASE_URL` | 本番 PostgreSQL（Neon。pooled + `sslmode=require`） |
+| `FRONTEND_URL` | CORS allowlist。開発: `http://localhost:3000`（デフォルト）/ 本番: `https://matcha-to-jinja.com`（#113〜） |
+| `JWT_SECRET_KEY` | API 用 JWT 署名（#115〜）。credentials の `jwt_secret` が優先 |
 | `RAILS_MASTER_KEY` | `credentials.yml.enc` 復号 |
 | `APP_HOSTS`（任意） | 本番の Host Authorization 追加許可リスト（カンマ区切り）。本番は常時有効で `*.run.app` を自動許可。カスタムドメインは本変数で追加する（未設定でも `*.run.app` のみ許可＝fail-open しない）。`/api/v1/health` は除外（#118） |
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@
 #
 # ⚠️ Greentea / Temple は保存時に住所ジオコーディングを行う（app/models/*.rb の
 #    `after_validation :geocode`）。この seed を流すと 1 レコードにつき Google Geocoding
-#    API を 1 回叩くため、GOOGLE_GEOCODING_API_KEY の設定とクォータ/課金に注意すること。
+#    API を 1 回叩くため、GMAP_API の設定とクォータ/課金に注意すること。
 #    詳細は docs/infra/deploy-runbook.md の「デプロイ前チェックリスト」を参照。
 require "csv"
 

--- a/docs/infra/deploy-runbook.md
+++ b/docs/infra/deploy-runbook.md
@@ -55,7 +55,7 @@
 - `Greentea` / `Temple` は保存時に住所ジオコーディングする（`after_validation :geocode`）。
   そのため **seed 1 行につき Google Geocoding API を 1 回**呼ぶ（合計 **≈530 リクエスト**: greentea 72 + temple 460）。
 - 事前確認:
-  - [ ] `GOOGLE_GEOCODING_API_KEY` を seed 実行環境に設定（未設定だと緯度経度が入らず**距離検索 API が壊れる**）
+  - [ ] `GMAP_API` を seed 実行環境に設定（`config/initializers/geocoder.rb` が参照。未設定だと緯度経度が入らず**距離検索 API が壊れる**）
   - [ ] 当該キーの API クォータ / 課金上限を確認（無料枠を超えると 429 / 課金）
   - [ ] 大量リクエストでレート制限に当たる場合は分割実行、または投入後に緯度経度 NULL の行がないか検証
     （`Greentea.where(latitude: nil).count` / `Temple.where(latitude: nil).count` が 0 であること）
@@ -238,6 +238,12 @@ echo "$SA"
 >
 > （根本対応として initializer を `ENV['LINE_KEY']` 参照へ寄せる選択肢もあるが、認証境界に
 > 触れるため本手順書のスコープ外。別 issue で扱う。）
+
+> ⚠️ **Directions API キーは現状 Cloud Run に渡されていない**
+> モデルルートの経路・所要時間計算（`app/services/directions_service.rb`・#153）は
+> `GOOGLE_DIRECTIONS_API_KEY`（未設定時は `GOOGLE_MAPS_API_KEY`）を参照するが、
+> `deploy-cloud-run.yml` はどちらの環境変数も渡していないため、本番では経路計算が
+> 無効（nil 返却）になる。本番で有効化する場合は workflow と Secrets への追加が必要。
 
 ### Variables
 


### PR DESCRIPTION
## 概要

環境変数まわりのドキュメントと実コードの表記揺れを解消し、開発者が最初に参照できる `.env.example` を追加しました。

- **`.env.example` を新規作成**
  - 実コードが `ENV[..]` で参照している変数名（`GMAP_API` / `GOOGLE_MAP_API` / `GOOGLE_DIRECTIONS_API_KEY` / `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` / `JWT_SECRET_KEY` 等）で記載
  - 各キーの取得方法（Google Cloud Console / LINE Developers）・APIキー制限の推奨・`bin/rails secret` での生成方法をコメントで併記
  - `dotenv-rails` 導入済みのため `cp .env.example .env` で開発にそのまま使える（`.env` は `.gitignore` 済み）
- **CLAUDE.md の必須環境変数表を実コードに合わせて修正**
  - `GOOGLE_GEOCODING_API_KEY` → `GMAP_API`（`config/initializers/geocoder.rb`）
  - `GOOGLE_MAPS_API_KEY` → `GOOGLE_MAP_API`（`app/views/**/*.erb`）
  - LINE OAuth は ENV では有効化されず `credentials.yml.enc` の `line.channel_id` / `line.channel_secret` のみ参照であることを明記
  - Google OAuth / JWT の credentials フォールバックを追記
- **`docs/infra/deploy-runbook.md` / `db/seeds.rb`** の `GOOGLE_GEOCODING_API_KEY` 表記を `GMAP_API` に統一
- **`deploy-runbook.md` に注記追加**: Directions API キー（`GOOGLE_DIRECTIONS_API_KEY` / フォールバックの `GOOGLE_MAPS_API_KEY`）が現状 `deploy-cloud-run.yml` から Cloud Run に渡されておらず、本番では経路計算が無効になる旨（対応自体はコード変更を伴うため別 issue 想定）
- **`deploy-cloud-run.yml`** の「CLAUDE.md と変数名が不一致（統一は別タスク）」という古いコメントを、統一済みの記述に更新

## 確認方法

1. `cp .env.example .env` して各値を埋め、`bin/dev` で起動できることを確認してください
2. `.env.example` 記載の変数名が実コードの参照と一致していることを確認してください
   - `grep -rn "ENV\['GMAP_API'\]" config/` → `config/initializers/geocoder.rb`
   - `grep -rn "GOOGLE_MAP_API" app/views/` → 地図描画の erb 3 箇所
   - `grep -rn "GOOGLE_DIRECTIONS_API_KEY" app/services/` → `directions_service.rb`
3. CLAUDE.md / deploy-runbook.md の環境変数表が上記と一致していることを確認してください

## 影響範囲

- ドキュメント（CLAUDE.md / docs/infra/deploy-runbook.md）とコメント（db/seeds.rb / deploy-cloud-run.yml）のみの変更で、**アプリの挙動・デプロイ処理に変更はありません**
- `.env.example` は新規ファイルで、既存の `.env` 読み込み挙動には影響しません

## チェックリスト

- [x] Lint のチェックをパスした（Ruby コードの変更は seeds.rb のコメント 1 行のみ）
- [x] 必要なドキュメントを作成した（.env.example / CLAUDE.md / deploy-runbook.md）
- [ ] インテグレーションテストを追加した（ドキュメントのみのため対象外）

## コメント

- `directions_service.rb` のフォールバック先が `GOOGLE_MAPS_API_KEY` で、地図描画用の `GOOGLE_MAP_API` と**別名**になっている点は今回触っていません（コード変更になるため）。Cloud Run に Directions キーを渡す対応とあわせて別 issue で扱うのがよさそうです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSJiFKrzaEaGXLoxxR2rPu

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSJiFKrzaEaGXLoxxR2rPu)_