### PR TITLE
fix: rspec-rails 8 対応のため fixture_path= を fixture_paths= に置き換え

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,7 +32,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_paths = [Rails.root.join('spec/fixtures')]
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
## 概要

Dependabot PR #208（rspec-rails 7.1.1 → 8.0.4）の CI が、全 spec のロード時に以下のエラーで失敗していました（39 errors）。

```
NoMethodError:
  undefined method 'fixture_path=' for #<RSpec::Core::Configuration>
# ./spec/rails_helper.rb:35
```

rspec-rails 8 で単数形の `config.fixture_path=` が削除されたためです。rspec-rails 6.1 以降で推奨されている複数形の `config.fixture_paths=` に移行します。

```ruby
# Before
config.fixture_path = "#{::Rails.root}/spec/fixtures"

# After
config.fixture_paths = [Rails.root.join('spec/fixtures')]
```

現行の rspec-rails 7.1.1 でも `fixture_paths=` はサポート済みのため、本 PR 単体でも後方互換があり CI に影響しません。

## 確認方法

1. 本 PR の CI（RuboCop / RSpec）がグリーンであることを確認してください
2. 本 PR のマージ後、#208 で `·@·d·ependabot r·ebase` とコメント（または Update branch）し、#208 の CI が通ることを確認してください

## 影響範囲

- `spec/rails_helper.rb` の 1 行のみ。テスト設定の変更であり、アプリケーションコードへの影響はありません
- fixture のパス解決先は `spec/fixtures` のまま変わりません

## チェックリスト

- [x] Lint のチェックをパスした（CI の RuboCop で確認）
- [x] ユニットテストをパスした（CI の RSpec で確認）

## コメント

rspec-rails 8 へのアップグレード（#208）の事前準備です。本 PR マージ後に #208 を rebase すれば、rspec-rails 8.0.4 の CI が通る想定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SoFrB3XLc2PLzQ5KEuUeNS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoFrB3XLc2PLzQ5KEuUeNS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test fixture configuration to use the current Rails path format.
  * This improves consistency with newer framework conventions and helps keep test setup reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->