### PR TITLE
docs: Rack 3 化済みのため Gemfile の古い非互換コメントを削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,6 @@ gem "pg", "~> 1.6"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", "~> 8.0"
 
-# Rack 3 は capybara 3.40 + puma 5 と非互換（rack/handler 削除）。
-# Rack 3 化は puma 6 / capybara 更新と合わせて別途対応する。
 gem "rack", "~> 3.2"
 
 # Bundle and transpile JavaScript [https://github.com/rails/jsbundling-rails]


### PR DESCRIPTION
## 概要

#225 で rack 2.2.23 → 3.2.6（Rack 3 化）をマージしたため、Gemfile に残っていた古い注記コメント 2 行を削除します。

削除したコメント:

```ruby
# Rack 3 は capybara 3.40 + puma 5 と非互換（rack/handler 削除）。
# Rack 3 化は puma 6 / capybara 更新と合わせて別途対応する。
```

ピン留め当時の理由は以下の通りいずれも解消済みです。

- puma 5 → 現在は puma 8.0.2
- capybara がアプリサーバーを起動する system spec → #136 段階1 で廃止済み

## 確認方法

1. Gemfile 18〜19 行目（`gem "rack", "~> 3.2"` の直上）から古いコメントが消えていることを確認してください
2. コメント削除のみの変更のため、`bundle install` 等の追加作業は不要です

## 影響範囲

Gemfile のコメント 2 行のみ。依存関係・ロックファイル・アプリケーションコードへの影響はありません。

## チェックリスト

- [x] Lint のチェックをパスした（CI: RuboCop）
- [x] ユニットテストをパスした（CI: RSpec）
- [ ] インテグレーションテストを追加した（対象外: コメント削除のみ）
- [ ] 必要なドキュメントを作成した（対象外）

## コメント

Rack 3 はレスポンスヘッダーの小文字化などランタイム挙動の変更があるため、次回の Cloud Run デプロイ後に主要画面（地図表示・OAuth ログイン・画像アップロード）の動作確認を推奨します（本 PR ではなく #225 の内容に対する補足です）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vb57EXWFmc6SBRxzVCCf38

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vb57EXWFmc6SBRxzVCCf38)_