### PR TITLE
feat: 本番 seed で抹茶店・ジャンルも投入できるようにする

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,28 +7,16 @@
 #   Character.create(name: "Luke", movie: movies.first)
 require "csv"
 
-# CSV.foreach('db/csv/genre.csv') do |row|
-#   Genre.find_or_create_by(:name => row[0])
-# end
-
-# CSV.foreach('db/csv/greentea.csv', headers: true) do |row|
-#   greentea = Greentea.find_or_create_by(
-#     name: row['name'],
-#     description: row['description'], 
-#     phone_number: row['phone_number'],
-#     address: row['address'],
-#     access: row['access'],
-#     business_hours: row['business_hours'],
-#     homepage: row['homepage'],
-#     holiday: row['holiday'])
-#   genres = Genre.where(name: row['genre'].split(' '))
-#   genres.each do |genre|
-#     greentea.greentea_genres.create(genre: genre)
-#   end
-# end
-
+# 神社の地域マスタ
 CSV.foreach('db/csv/area.csv', headers: true) do |row|
   Area.find_or_create_by!(name: row['name'])
+end
+
+# 抹茶店のジャンルマスタ。抹茶店の紐付けはこのマスタに存在するジャンルのみ対象とし、
+# CSV 側の表記揺れで未知のジャンルが来ても新規ジャンルは作らない（重複防止）
+CSV.foreach('db/csv/genre.csv', headers: false) do |row|
+  name = row[0].to_s.strip
+  Genre.find_or_create_by!(name: name) unless name.empty?
 end
 
 CSV.foreach('db/csv/temple_info.csv', headers: true) do |row|
@@ -46,4 +34,24 @@ CSV.foreach('db/csv/temple_info.csv', headers: true) do |row|
 
   area = Area.find_by!(name: row['area'])
   temple.temple_areas.find_or_create_by!(area: area)
+end
+
+CSV.foreach('db/csv/greentea_info.csv', headers: true) do |row|
+  greentea = Greentea.find_or_initialize_by(name: row['name'], address: row['address'])
+  greentea.assign_attributes(
+    description: row['description'],
+    phone_number: row['phone_number'],
+    address: row['address'],
+    access: row['access'],
+    business_hours: row['business_hours'],
+    homepage: row['homepage'],
+    holiday: row['holiday']
+  )
+  greentea.save!
+
+  # ジャンルは半角スペース区切り。マスタに存在するものだけ紐付ける
+  genre_names = row['genre'].to_s.split(/[[:space:]]+/).reject(&:empty?)
+  Genre.where(name: genre_names).each do |genre|
+    greentea.greentea_genres.find_or_create_by!(genre: genre)
+  end
 end


### PR DESCRIPTION
## 概要

本番デプロイ（#118）に向けて、`db/seeds.rb` が **Area（地域）と Temple（神社）しか投入していなかった**問題を修正し、**Greentea（抹茶店）と Genre（ジャンル）、および両者の紐付けも投入できるように**した。

これまでの seeds.rb では抹茶店・ジャンルの読み込みがコメントアウトされたままだったため、本番で `db:seed` を流すと抹茶店データが 0 件になる状態だった。本 PR でスポット全件が揃うようになる。

### 変更点

- Genre マスタを `db/csv/genre.csv` から投入（`find_or_create_by!`）
- Greentea を `db/csv/greentea_info.csv` から投入。既存の Temple ブロックと同じ `find_or_initialize_by(name:, address:)` → `assign_attributes` → `save!` パターンに揃え、**再実行しても重複しない冪等な seed** にした
- 抹茶店とジャンルの紐付けを追加。ジャンルは半角スペース区切りで、**マスタ（genre.csv）に存在するもののみ紐付ける**
  - CSV 側の表記揺れ（データ「プルプルスイーツ」／マスタ「ぷるぷるスイーツ」）で未知ジャンルが来ても、seed 側で新規ジャンルを作らずスキップし、重複を防止

## 確認方法

1. スキーマ未適用の DB に対して以下を実行:
   ```bash
   RAILS_ENV=production bin/rails db:schema:load
   RAILS_ENV=production bin/rails db:seed
   ```
   - ※ `Greentea` / `Temple` は保存時に `after_validation :geocode` で Google Geocoding API を叩くため、seed 実行環境に `GMAP_API`（Geocoding キー）が必要
2. 投入結果を確認:
   ```ruby
   Genre.count     # => 17
   Greentea.count  # => 73
   GreenteaGenre.count  # => 178
   ```
3. `db:seed` をもう一度流しても件数が増えない（冪等）ことを確認

## 影響範囲

- `db/seeds.rb` のみ。アプリのランタイムコード・スキーマ・マイグレーションには変更なし
- 本番 / 開発 / テストいずれの seed 実行にも影響する（テスト DB は CI 上 seed を回さない運用のため実害なし）
- 既存の Area / Temple 投入ロジックは変更なし

## チェックリスト

- [x] Lint のチェックをパスした（seeds.rb は `ruby -c` で構文確認。RuboCop は CI で検証）
- [x] CSV パースのドライラン検証を実施（ジャンル17 / 抹茶店73 / 紐付け178、マスタ全17ジャンルが使用され、未知ジャンルはスキップされることを確認）
- [ ] ユニットテストの追加（seed はテスト対象外のため未追加）

## コメント

- ジャンルの表記揺れ（`greentea_info.csv` の「プルプルスイーツ」）は seed 側では吸収せずスキップしている。データを正とするなら `db/csv/greentea_info.csv` 側を「ぷるぷるスイーツ」に修正するのが本筋だが、CSV データの修正は別対応が望ましいと考え本 PR のスコープ外とした
- 本番での seed 実行フロー（Neon への流し込み手順）は `docs/infra/deploy-runbook.md` の §3・§8 を参照


---
_Generated by [Claude Code](https://claude.ai/code/session_01FTwdq53XcbaLAPEvEnTr2E)_